### PR TITLE
Ignore commented lines during string check

### DIFF
--- a/lib/puppet-lint/plugins/check_strings.rb
+++ b/lib/puppet-lint/plugins/check_strings.rb
@@ -3,7 +3,7 @@ class PuppetLint::Plugins::CheckStrings < PuppetLint::CheckPlugin
     line_no = 0
     data.each_line do |line|
       line_no += 1
-      line.match(/"([^\\"]|\\\\|\\")*"/).to_a.each do |s|
+      line.match(/^[^\s?#].*"([^\\"]|\\\\|\\")*"/).to_a.each do |s|
         if s.is_a? String and s.start_with? '"'
           variable_found = false
           s.scan(/.\$./) do |w|


### PR DESCRIPTION
As per issue #22, commented lines should be immune from the string check.

(This is a pretty minor modification. ;) )
