### PR TITLE
When running puppet-lint on multiple files is it nice to have it print ou

### DIFF
--- a/bin/puppet-lint
+++ b/bin/puppet-lint
@@ -44,6 +44,7 @@ end
 begin
   l = PuppetLint.new
   l.file = ARGV[0]
+  puts ARGV[0]
   l.run
 rescue PuppetLint::NoCodeError
   puts "puppet-lint: no file specified or specified file does not exist"


### PR DESCRIPTION
When running puppet-lint on multiple files is it nice to have it print out the filename.

For example when running:

find . -name "*.pp" -exec puppet-lint {} \; 
