### PR TITLE
Add option to include filenames when reporting back

### DIFF
--- a/bin/puppet-lint
+++ b/bin/puppet-lint
@@ -26,6 +26,10 @@ opts = OptionParser.new do |opts|
     exit 0
   end
 
+  opts.on("--with-filename", "Display the filename before the warning") do
+    options[:with_filename] = true
+  end
+
   opts.on("--fail-on-warnings", "Return a non-zero exit status for warnings.") do
     options[:fail_on_warnings] = true
   end
@@ -49,6 +53,7 @@ end
 begin
   l = PuppetLint.new
   l.file = ARGV[0]
+  l.show_filename = options.has_key?(:with_filename) ? options[:with_filename] : false
   l.run
 
   if l.errors? or (l.warnings? and options[:fail_on_warnings])


### PR DESCRIPTION
When checking multiple files at once, It's anoying you cant really see what error/warning goes with what puppet file. This includes the option --with-filename that will prepend the messages with the path to the file.
