### PR TITLE
Add filename as first test() argument so plugins can use that too

### DIFF
--- a/lib/puppet-lint.rb
+++ b/lib/puppet-lint.rb
@@ -57,7 +57,7 @@ class PuppetLint
     end
 
     PuppetLint::CheckPlugin.repository.each do |plugin|
-      problems = plugin.new.run(@data)
+      problems = plugin.new.run(@path, @data)
       problems[:errors].each { |error| report :errors, error }
       problems[:warnings].each { |warning| report :warnings, warning }
     end

--- a/lib/puppet-lint/plugin.rb
+++ b/lib/puppet-lint/plugin.rb
@@ -33,8 +33,8 @@ class PuppetLint::CheckPlugin
     @errors << message
   end
 
-  def run(data)
-    test(data)
+  def run(path, data)
+    test(path, data)
 
     {:warnings => @warnings, :errors => @errors}
   end

--- a/lib/puppet-lint/plugins/check_classes.rb
+++ b/lib/puppet-lint/plugins/check_classes.rb
@@ -1,5 +1,5 @@
 class PuppetLint::Plugins::CheckClasses < PuppetLint::CheckPlugin
-  def test(data)
+  def test(path, data)
     lexer = Puppet::Parser::Lexer.new
     lexer.string = data
     tokens = lexer.fullscan

--- a/lib/puppet-lint/plugins/check_conditionals.rb
+++ b/lib/puppet-lint/plugins/check_conditionals.rb
@@ -1,5 +1,5 @@
 class PuppetLint::Plugins::CheckConditionals < PuppetLint::CheckPlugin
-  def test(data)
+  def test(path, data)
     lexer = Puppet::Parser::Lexer.new
     lexer.string = data
     tokens = lexer.fullscan

--- a/lib/puppet-lint/plugins/check_resources.rb
+++ b/lib/puppet-lint/plugins/check_resources.rb
@@ -2,7 +2,7 @@
 # http://docs.puppetlabs.com/guides/style_guide.html#resources
 
 class PuppetLint::Plugins::CheckResources < PuppetLint::CheckPlugin
-  def test(data)
+  def test(path, data)
     lexer = Puppet::Parser::Lexer.new
     lexer.string = data
     tokens = lexer.fullscan

--- a/lib/puppet-lint/plugins/check_strings.rb
+++ b/lib/puppet-lint/plugins/check_strings.rb
@@ -14,7 +14,7 @@ class PuppetLint::Plugins::CheckStrings < PuppetLint::CheckPlugin
     end
   end
 
-  def test(data)
+  def test(path, data)
     l = Puppet::Parser::Lexer.new
     l.string = data
     tokens = l.fullscan

--- a/lib/puppet-lint/plugins/check_whitespace.rb
+++ b/lib/puppet-lint/plugins/check_whitespace.rb
@@ -2,7 +2,7 @@
 # http://http://docs.puppetlabs.com/guides/style_guide.html#spacing-indentation--whitespace
 
 class PuppetLint::Plugins::CheckWhitespace < PuppetLint::CheckPlugin
-  def test(data)
+  def test(path, data)
     line_no = 0
     in_resource = false
     in_selector = false


### PR DESCRIPTION
It might be useful to pass the path of a filename to the plugin so new plugins can do filename checking or use the path to run an 'external' check.
