### PR TITLE
Fixed #45 - Added selective error level reporting

### DIFF
--- a/bin/puppet-lint
+++ b/bin/puppet-lint
@@ -26,6 +26,11 @@ opts = OptionParser.new do |opts|
     exit 0
   end
 
+  options[:error_level] = :all
+  opts.on("--error-level LEVEL", [:all, :warning, :error], "The level of error to return (warning, error, all).") do |el|
+    options[:error_level] = el
+  end
+
   opts.on("--fail-on-warnings", "Return a non-zero exit status for warnings.") do
     options[:fail_on_warnings] = true
   end
@@ -47,7 +52,7 @@ if ARGV[0].nil?
 end
 
 begin
-  l = PuppetLint.new
+  l = PuppetLint.new(options)
   l.file = ARGV[0]
   l.run
 

--- a/lib/puppet-lint.rb
+++ b/lib/puppet-lint.rb
@@ -17,10 +17,11 @@ class PuppetLint
 
   attr_reader :code, :file
 
-  def initialize
+  def initialize(options)
     @data = nil
     @errors = 0
     @warnings = 0
+    @error_level = options[:error_level]
   end
 
   def file=(path)
@@ -58,8 +59,15 @@ class PuppetLint
 
     PuppetLint::CheckPlugin.repository.each do |plugin|
       problems = plugin.new.run(@data)
-      problems[:errors].each { |error| report :errors, error }
-      problems[:warnings].each { |warning| report :warnings, warning }
+      case @error_level
+      when :warning
+        problems[:warnings].each { |warning| report :warnings, warning }
+      when :error
+        problems[:errors].each { |error| report :errors, error }
+      else
+        problems[:warnings].each { |warning| report :warnings, warning }
+        problems[:errors].each { |error| report :errors, error }
+      end
     end
   end
 end


### PR DESCRIPTION
Added a new command-line option `--error-level` with
values of:
- warning - only return warning messages
- error - only return error messages
- all - the default return all messages
