### PR TITLE
[#9] add stack to allow nested hashes

### DIFF
--- a/spec/puppet-lint/check_whitespace_spec.rb
+++ b/spec/puppet-lint/check_whitespace_spec.rb
@@ -61,4 +61,21 @@ describe PuppetLint::Plugins::CheckWhitespace do
     its(:warnings) { should be_empty }
     its(:errors) { should be_empty }
   end
+
+  describe 'selector inside a hash inside a resource' do
+    let(:code) { "
+    server => {
+      ensure => ensure => $ensure ? {
+        present => directory,
+        absent  => undef,
+      },
+      ip     => '192.168.1.1'
+    },
+    owner  => 'foo4',
+    group  => 'foo4',
+    mode   => '0755'," }
+
+    its(:warnings) { should be_empty }
+    its(:errors) { should be_empty }
+  end
 end


### PR DESCRIPTION
This patch abuses selectors to allow nested hashes in manifests to
have different indents as they should for clarity.  It maintains a
stack of indents so that it enforces things properly.
