### PR TITLE
Fix error when running RakeTask in 1.9.x

### DIFF
--- a/lib/puppet-lint.rb
+++ b/lib/puppet-lint.rb
@@ -25,7 +25,7 @@ class PuppetLint
 
   attr_reader :code, :file
 
-  def initialize(options)
+  def initialize(options = {})
     @data = nil
     @errors = 0
     @warnings = 0
@@ -46,7 +46,6 @@ class PuppetLint
   end
 
   def report(kind, message)
-    #msg = message
     if kind == :warnings
       @warnings += 1
       message.prepend('WARNING: ')


### PR DESCRIPTION
The RakeTask initializes Linter without any args, but in 1.9 the arguments are necessary
