### PR TITLE
Fixup the variable not enclosed in {} test

### DIFF
--- a/lib/puppet-lint/plugins/check_strings.rb
+++ b/lib/puppet-lint/plugins/check_strings.rb
@@ -45,7 +45,8 @@ class PuppetLint::Plugins::CheckStrings < PuppetLint::CheckPlugin
       token = tokens[token_idx]
 
       if token.first == :DQPRE
-        end_of_string_idx = tokens[token_idx..-1].index { |r| r.first == :DQPOST }
+        end_of_string_offset = tokens[token_idx..-1].index { |r| r.first == :DQPOST }
+        end_of_string_idx = token_idx + end_of_string_offset
         tokens[token_idx..end_of_string_idx].each do |t|
           if t.first == :VARIABLE
             line = data.split("\n")[t.last[:line] - 1]

--- a/spec/puppet-lint/check_strings_spec.rb
+++ b/spec/puppet-lint/check_strings_spec.rb
@@ -39,6 +39,16 @@ describe PuppetLint::Plugins::CheckStrings do
 
   end
 
+  describe 'variable not enclosed in {} after many tokens' do
+    let(:code) { ("'groovy'\n" * 20) + '" $gronk"' }
+
+    its(:problems) {
+      should only_have_problem :kind => :warning, :message => "variable not enclosed in {}", :linenumber => '21'
+    }
+
+  end
+
+
   describe 'double quoted string nested in a single quoted string' do
     let(:code) { "'grep \"status=sent\" /var/log/mail.log'" }
 


### PR DESCRIPTION
In the simple test case already in play, the index offsets would
all wind up tiny and land you on the correct codepath accidentally.

This adds a test case which deliberately buries the bad line some
20 lines down, so it's not in the first few tokens parsed.
