### PR TITLE
Update travis support for multiple puppet version.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,18 +2,18 @@ rvm:
   - 1.8.7
   - 1.9.2
   - 1.9.3
-gemfile:
-  - gemfiles/Gemfile.puppet-2.6
-  - gemfiles/Gemfile.puppet-2.7
 branches:
   only:
     - master
 notifications:
   email:
     - tim@github.com
+env:
+  - PUPPET_VERSION=2.6.13
+  - PUPPET_VERSION=2.7.9
 matrix:
   exclude:
     - rvm: 1.9.2
-      gemfile: gemfiles/Gemfile.puppet-2.6
+      env: PUPPET_VERSION=2.6.13
     - rvm: 1.9.3
-      gemfile: gemfiles/Gemfile.puppet-2.6
+      env: PUPPET_VERSION=2.6.13

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,8 @@
+source :rubygems
+
+puppetversion = ENV.key?('PUPPET_VERSION') ? "= #{ENV['PUPPET_VERSION']}" : ['>= 2.7']
+
+gem 'rake'
+gem 'rspec'
+gem 'rdoc'
+gem 'puppet', puppetversion

--- a/gemfiles/Gemfile.puppet-2.6
+++ b/gemfiles/Gemfile.puppet-2.6
@@ -1,6 +1,0 @@
-source :rubygems
-
-gem 'rake'
-gem 'rspec'
-gem 'rdoc'
-gem 'puppet', '2.6.13'

--- a/gemfiles/Gemfile.puppet-2.7
+++ b/gemfiles/Gemfile.puppet-2.7
@@ -1,6 +1,0 @@
-source :rubygems
-
-gem 'rake'
-gem 'rspec'
-gem 'rdoc'
-gem 'puppet', '2.7.9'


### PR DESCRIPTION
Instead of maintaining multiple gemfiles, a single gemfile can load any
puppet version specified in travis.yml. This should simplify testing for
new version of puppet.
