### PR TITLE
Add support run puppet-lint on directory.

### DIFF
--- a/bin/puppet-lint
+++ b/bin/puppet-lint
@@ -80,13 +80,21 @@ if ARGV[0].nil?
 end
 
 begin
-  l = PuppetLint.new
-  l.file = ARGV[0]
-  l.run
-
-  if l.errors? or (l.warnings? and PuppetLint.configuration.fail_on_warnings)
-    exit 1
+  path = ARGV[0]
+  if File.directory?(path)
+    Dir.chdir(path)
+    path = Dir.glob('**/*.pp')
   end
+
+  path.each do |f|
+    l = PuppetLint.new
+    l.file = f
+    l.run
+    if l.errors? or (l.warnings? and PuppetLint.configuration.fail_on_warnings)
+      exit 1
+    end
+  end
+
 rescue PuppetLint::NoCodeError
   puts "puppet-lint: no file specified or specified file does not exist"
   puts "puppet-lint: try 'puppet-lint --help' for more information"


### PR DESCRIPTION
The patch adds the ability to run puppet-lint on an entire directory by
globbing *_/_.pp and this will output the file with the lint issue to
help user track down what issues occur in which file.
