### PR TITLE
Build glob syntax support into the [PuppetLint] class by default.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,10 @@ guide](http://docs.puppetlabs.com/guides/style_guide.html) as practical.
 
 You can test a single manifest file by running
 
-    puppet-lint <path to file>
+    puppet-lint <path or glob>
+
+e.g.
+    puppet-lint ./**/*.pp
 
 ### Rake task
 

--- a/bin/puppet-lint
+++ b/bin/puppet-lint
@@ -80,24 +80,7 @@ if ARGV[0].nil?
 end
 
 begin
-  path = ARGV[0]
-  if File.directory?(path)
-    Dir.chdir(path)
-    path = Dir.glob('**/*.pp')
-  end
-
-  path.each do |f|
-    l = PuppetLint.new
-    l.file = f
-    l.run
-    if l.errors? or (l.warnings? and PuppetLint.configuration.fail_on_warnings)
-      exit 1
-    end
-  end
-
-rescue PuppetLint::NoCodeError
-  puts "puppet-lint: no file specified or specified file does not exist"
-  puts "puppet-lint: try 'puppet-lint --help' for more information"
-  exit
+  l = PuppetLint.new(ARGV[0])
+  l.run
 end
 

--- a/lib/puppet-lint/tasks/puppet-lint.rb
+++ b/lib/puppet-lint/tasks/puppet-lint.rb
@@ -9,12 +9,8 @@ class PuppetLint
 
       task :lint do
         RakeFileUtils.send(:verbose, true) do
-          linter =  PuppetLint.new
-          Dir.glob('**/*.pp').each do |puppet_file|
-            puts "Evaluating #{puppet_file}"
-            linter.file = puppet_file
-            linter.run
-          end
+          linter = PuppetLint.new('**/*.pp')
+          linter.run
           fail if linter.errors?
         end
       end


### PR DESCRIPTION
Hey,

Firstly, _awesome_ tool, thanks!

Thought that it might be nice to have glob syntax be part of the [PuppetLint] class. 

As a result I was able to remove all setters (OOP & encapsulation yay) and it exposed another [bit of replication](https://github.com/clowder/puppet-lint/compare/glob-syntax-support#L2R140) that could be moved to a new home (another feature branch coming soon).

Hope this looks OK to you?

Cheers,
Chris
