### PR TITLE
Update readme to reflect the current names of the flags for disabling checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,11 +230,11 @@ Placeholder
 ### puppet-lint
 
 You can disable any of the checks when running the `puppet-lint` command by
-adding a `--disable-<check name>` flag to the command.  For example, if you
+adding a `--no-<check name>-check` flag to the command.  For example, if you
 wanted to skip the 80 character check, you would run
 
 ```
-puppet-lint --disable-80chars /path/to/my/manifest.pp
+puppet-lint --no-80chars-check /path/to/my/manifest.pp
 ```
 
 puppet-lint will also check for a `.puppet-lintrc` file in the current
@@ -243,8 +243,15 @@ wanted to always skip the hard tab character check, you could create
 `~./puppet-lintrc` containing
 
 ```
---disable-hard_tabs
+--no-hard_tabs-check
 ```
+
+For a list of all the flags just type:
+
+```
+puppet-lint --help
+```
+
 
 ### Rake task
 


### PR DESCRIPTION
Using the previously documented flags on 0.1.12 throws a OptionParser::InvalidOption exception. I've updated the docs as per the command from --help that appear to work correctly.
