### PR TITLE
Fix bug introduced in #81

### DIFF
--- a/bin/puppet-lint
+++ b/bin/puppet-lint
@@ -84,6 +84,8 @@ begin
   if File.directory?(path)
     Dir.chdir(path)
     path = Dir.glob('**/*.pp')
+  else
+    path = [path]
   end
 
   path.each do |f|


### PR DESCRIPTION
Same issue as @tbroyer had in [his comment](https://github.com/rodjek/puppet-lint/pull/81#issuecomment-4752888) on #81 - his fix seems to solve the issue.

```
/Users/deizel/.rvm/gems/ruby-1.9.3-p125/gems/puppet-lint-0.1.13/bin/puppet-lint:91:in `<top (required)>': undefined method `each' for "modules/apache/manifests/spec.pp":String (NoMethodError)
    from /Users/deizel/.rvm/gems/ruby-1.9.3-p125/bin/puppet-lint:19:in `load'
    from /Users/deizel/.rvm/gems/ruby-1.9.3-p125/bin/puppet-lint:19:in `<main>'
```
