### PR TITLE
Excluding lines commented with #

### DIFF
--- a/lib/puppet-lint/plugins/check_strings.rb
+++ b/lib/puppet-lint/plugins/check_strings.rb
@@ -26,7 +26,7 @@ class PuppetLint::Plugins::CheckStrings < PuppetLint::CheckPlugin
       token = tokens[token_idx]
 
       if token.first == :STRING
-        unless token.last[:value].include? "\t" or token.last[:value].include? "\n"
+        unless token.last[:value].include? "\t" or token.last[:value].include? "\n" or token.first[:value].include? "#"
           notify :warning, :message =>  "double quoted string containing no variables", :linenumber => token.last[:line]
         end
       elsif token.first == :DQTEXT


### PR DESCRIPTION
I have seen that there were a couple of issues relating to ignoring commented lines and the non-trivial nature of ignoring lines with # (as per https://github.com/rodjek/puppet-lint/pull/25)

https://github.com/rodjek/puppet-lint/issues/77
https://github.com/rodjek/puppet-lint/issues/22

I was finding that trailing whitespaces, etc were being reported on commented lines and our manifests have a lot of comments.

So I have modified check_strings.rb and check_whitespace.rb and wrapped things up with a regex to not check if the line starts with # (INGORING whitespaces)

<pre>
  if ( line =~ /^#/x )
    ....
    ....
    ....
  end
</pre>


This works for all our comments and matches:

<pre>
# comment
    # deprecated
</pre>


Probably not the best method but fixes my needs.  It would probably be better to wrap all line functions in something similar, but you would know what and how is best :)

Nice tool BTW thanks, it helps with 2.6 to 2.7 variable refactoring, I hope that changes in the puppet 2.8.x/3.x do not result in too much refactoring for puppet-lint.

Regards
Gary
