### PR TITLE
Fix NoMethodError with Ruby 1.9.2

### DIFF
--- a/bin/puppet-lint
+++ b/bin/puppet-lint
@@ -80,10 +80,13 @@ if ARGV[0].nil?
 end
 
 begin
-  path = ARGV[0]
-  if File.directory?(path)
-    Dir.chdir(path)
+  origpath = ARGV[0]
+  if File.directory?(origpath)
+    Dir.chdir(origpath)
     path = Dir.glob('**/*.pp')
+  else
+    path = Array.new
+    path.push origpath
   end
 
   path.each do |f|


### PR DESCRIPTION
This fixes the NoMethodError that's encountered when trying to use puppet-lint with a single file under Ruby 1.9.2.  This was bug #103 
