### PR TITLE
Add support for ignoring certain globs in the rake task

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,13 @@ So, to disable the 80 character check, you would add:
 PuppetLint.configuration.send("disable_80chars")
 ```
 
+The Rake task also supports ignoring certain paths
+from being linted:
+
+``` ruby
+PuppetLint.configuration.ignore_paths = ["vendor/**/*.pp"]
+```
+
 ## Reporting bugs or incorrect results
 
 If you find a bug in puppet-lint or its results, please create an issue in the

--- a/lib/puppet-lint/configuration.rb
+++ b/lib/puppet-lint/configuration.rb
@@ -53,5 +53,9 @@ class PuppetLint
         method[0..-10]
       }
     end
+
+    def self.ignore_paths
+      settings[:ignore_paths] ||= []
+    end
   end
 end

--- a/lib/puppet-lint/tasks/puppet-lint.rb
+++ b/lib/puppet-lint/tasks/puppet-lint.rb
@@ -9,8 +9,14 @@ class PuppetLint
 
       task :lint do
         RakeFileUtils.send(:verbose, true) do
-          linter =  PuppetLint.new
-          Dir.glob('**/*.pp').each do |puppet_file|
+          linter = PuppetLint.new
+          matched_files = FileList['**/*.pp']
+
+          if ignore_paths = PuppetLint.configuration.ignore_paths
+            matched_files = matched_files.exclude(*ignore_paths)
+          end
+
+          matched_files.to_a.each do |puppet_file|
             puts "Evaluating #{puppet_file}"
             linter.file = puppet_file
             linter.run


### PR DESCRIPTION
With this change, the rake task now checks for the presence of `PuppetLint.configuration.ignore_paths` as an array of glob-strings to exclude certain files from being linted.

This is useful for cases where projects have Puppet vendored so its included manifests and modules for testing don't get picked up by the linter.
