### PR TITLE
Make rake task respect PuppetLint.configuration.fail_on_warnings

### DIFF
--- a/lib/puppet-lint/tasks/puppet-lint.rb
+++ b/lib/puppet-lint/tasks/puppet-lint.rb
@@ -21,7 +21,9 @@ class PuppetLint
             linter.file = puppet_file
             linter.run
           end
-          fail if linter.errors?
+          fail if linter.errors? || (
+            linter.warnings? && PuppetLint.configuration.fail_on_warnings
+          )
         end
       end
     end


### PR DESCRIPTION
Right now only the puppet-lint binary respects this config option.
