### PR TITLE
issue 120: improve path handling on CLI

### DIFF
--- a/bin/puppet-lint
+++ b/bin/puppet-lint
@@ -80,22 +80,23 @@ if ARGV[0].nil?
 end
 
 begin
-  path = ARGV[0]
-  if File.directory?(path)
-    Dir.chdir(path)
+  path = ARGV
+  if File.directory?(path[0])
+    Dir.chdir(path[0])
     path = Dir.glob('**/*.pp')
-  else
-    path = [path]
   end
 
   path.each do |f|
+    puts f.to_s + ':'
     l = PuppetLint.new
     l.file = f
     l.run
+    puts ''
     if l.errors? or (l.warnings? and PuppetLint.configuration.fail_on_warnings)
-      exit 1
+      exitstatus = 1
     end
   end
+  exit #{exitstatus}
 
 rescue PuppetLint::NoCodeError
   puts "puppet-lint: no file specified or specified file does not exist"


### PR DESCRIPTION
- handle multiple input files as arguments
- support Ruby 1.9.3.194

Addressing:

/var/lib/gems/1.9.1/gems/puppet-lint-0.1.13/bin/puppet-lint:89:in `<top (required)>': undefined method`each' for "base.pp":String (NoMethodError)
    from /usr/local/bin/puppet-lint:19:in `load'
    from /usr/local/bin/puppet-lint:19:in`<main>'

This changeset implements the patch described by @ferrylandzaat
in rodjek/puppet-lint#120 and resolves the above traceback as well
as enabling the CLI to handle multiple files as arguments.
