### PR TITLE
enable puppet-lint to be called within ruby

### DIFF
--- a/spec/puppet-lint_spec.rb
+++ b/spec/puppet-lint_spec.rb
@@ -7,4 +7,20 @@ describe PuppetLint do
     subject.code = "class foo { }"
     subject.data.should_not be_nil
   end
+
+  describe '#new' do
+    it 'should not be quiet' do
+      # ensure backward compatibility
+      subject.quiet?.should be_false
+    end
+
+    it 'should have problems array' do
+      subject.problems.should be_a_kind_of(Array)
+    end
+
+    it 'problems should be empty' do
+      subject.problems.should be_empty
+    end
+  end
+
 end


### PR DESCRIPTION
This changeset enables puppet-lint to be used as a library within other Ruby code, such as a cross-platform git commit hook.
- add ability to suppress normal output
- enable access to array of problems (if any)
- enable access to statistics
- add rspec to ensure backward compatibility
- update README.md to demonstrate use case
