### PR TITLE
Fix for double quoted string check including newlines

### DIFF
--- a/lib/puppet-lint/plugins/check_strings.rb
+++ b/lib/puppet-lint/plugins/check_strings.rb
@@ -10,7 +10,7 @@ class PuppetLint::Plugins::CheckStrings < PuppetLint::CheckPlugin
     }.each { |r|
       r.value.gsub!(' '*r.column, "\n")
     }.reject { |r|
-      r.value.include?("\t") || r.value.include?("\n")
+      r.value.include?('\t') || r.value.include?('\n')
     }.each do |token|
       notify :warning, {
         :message    => 'double quoted string containing no variables',


### PR DESCRIPTION
Check for escaped newlines, not newlines and tabs themselves.
