### PR TITLE
(#148) Allow class inheritance within the same module

### DIFF
--- a/lib/puppet-lint/plugins/check_classes.rb
+++ b/lib/puppet-lint/plugins/check_classes.rb
@@ -218,8 +218,10 @@ class PuppetLint::Plugins::CheckClasses < PuppetLint::CheckPlugin
 
       if inherits_token.type == :INHERITS
         inherited_class_token = inherits_token.next_code_token
+        inherited_module_name = inherited_class_token.value.split('::').reject { |r| r.empty? }.first
+        class_module_name = class_name_token.value.split('::').reject { |r| r.empty? }.first
 
-        unless class_name_token.value =~ /^#{inherited_class_token.value}::/
+        unless class_module_name == inherited_module_name
           notify :warning, {
             :message    => "class inherits across module namespaces",
             :linenumber => inherited_class_token.line,

--- a/spec/puppet-lint/plugins/check_classes/inherits_across_namespaces_spec.rb
+++ b/spec/puppet-lint/plugins/check_classes/inherits_across_namespaces_spec.rb
@@ -7,6 +7,12 @@ describe 'inherits_across_namespaces' do
     its(:problems) { should be_empty }
   end
 
+  describe 'class inheriting from sister in same module namespace' do
+    let(:code) { "class foo::bar inherits foo::baz { }" }
+
+    its(:problems) { should be_empty }
+  end
+
   describe 'class inheriting from another module namespace' do
     let(:code) { "class foo::bar inherits baz { }" }
 


### PR DESCRIPTION
Fixes issue #148

The wording of [11.5 Class Inheritance](http://docs.puppetlabs.com/guides/style_guide.html#class-inheritance) doesn't state that the super-class has to be a direct namespace-parent of the sub-class. Only that they have to exist within the same module (ie. root namespace).

> Inheritance may be used within a module, but must not be used across module namespaces.

This changes the `inherits_across_namespaces` check to compare the first part of the class name and ensure they belong to the same module. Warning message and test names are changed slightly to reflect this behaviour. Additional test is added to confirm this behaviour.
