### PR TITLE
Allow blank lines in trailing_whitespace

### DIFF
--- a/lib/puppet-lint/plugins/check_whitespace.rb
+++ b/lib/puppet-lint/plugins/check_whitespace.rb
@@ -21,12 +21,14 @@ class PuppetLint::Plugins::CheckWhitespace < PuppetLint::CheckPlugin
   # Returns nothing.
   check 'trailing_whitespace' do
     manifest_lines.each_with_index do |line, idx|
-      if line.end_with? ' '
-        notify :error, {
-          :message    => 'trailing whitespace found',
-          :linenumber => idx + 1,
-          :column     => line.rindex(' ') + 1,
-        }
+      unless line =~ /^\s+$/
+        if line.end_with? ' '
+          notify :error, {
+            :message    => 'trailing whitespace found',
+            :linenumber => idx + 1,
+            :column     => line.rindex(' ') + 1,
+          }
+        end
       end
     end
   end

--- a/lib/puppet-lint/version.rb
+++ b/lib/puppet-lint/version.rb
@@ -1,3 +1,3 @@
 class PuppetLint
-  VERSION = '0.3.2'
+  VERSION = '0.3.2.1'
 end


### PR DESCRIPTION
Currently the trailing_whitespace check flags a line with only
whitespace (ie. as inserted by most code focussed text editors when
leaving a blank line within an indented block of code).
This allows lines that have only space chars (regex \s) between the
start and end. Not sure if this is the most elegant way to achieve
this, I don't know the puppet-lint tree that well.

I also bumped the version to allow me to run it in my own gem repo, so obviously ignore that bit!
