### PR TITLE
Use the current workdir as reference to calculate the expanded_path of a filename

### DIFF
--- a/lib/puppet-lint.rb
+++ b/lib/puppet-lint.rb
@@ -39,7 +39,8 @@ class PuppetLint
   def file=(path)
     if File.exist? path
       @fileinfo[:path] = path
-      @fileinfo[:fullpath] = File.expand_path(path)
+      ## expand path but use the current directory as reference.
+      @fileinfo[:fullpath] = File.expand_path(path, ENV['PWD'])
       @fileinfo[:filename] = File.basename(path)
       @code = File.read(path)
     end


### PR DESCRIPTION
This resolves issues with autoloader layout detection when the module dir
is a symlink.

```
.
├── foobar -> foo-bar/
└── foo-bar
    └── manifests
            ├── foo.pp
            └── init.pp
```

Running puppet-lint in ./foobar results in:

```
WARNING: class not documented on line 1
ERROR: foobar not in autoload module layout on line 1
WARNING: class not documented on line 1
ERROR: foobar::foo not in autoload module layout on line 1
```
