### PR TITLE
Fix the check_classes check for certain cases.

### DIFF
--- a/lib/puppet-lint/plugins/check_classes.rb
+++ b/lib/puppet-lint/plugins/check_classes.rb
@@ -26,9 +26,9 @@ class PuppetLint::Plugins::CheckClasses < PuppetLint::CheckPlugin
         split_title = title_token.value.split('::')
         mod = split_title.first
         if split_title.length > 1
-          expected_path = "#{mod}/manifests/#{split_title[1..-1].join('/')}.pp"
+          expected_path = "/#{mod}/manifests/#{split_title[1..-1].join('/')}.pp"
         else
-          expected_path = "#{title_token.value}/manifests/init.pp"
+          expected_path = "/#{title_token.value}/manifests/init.pp"
         end
 
         unless fullpath.end_with? expected_path


### PR DESCRIPTION
Examples:

File: modules/foobar/manifests/init.pp
Content: 'class bar { }'

File: modules/foobar/manifests/fail.pp
Content: 'class bar::fail {}'

These 2 examples do not throw the autoloader error while they really should.
