### PR TITLE
Write files in binary mode to avoid writing CRLFs on windows

### DIFF
--- a/lib/puppet-lint/bin.rb
+++ b/lib/puppet-lint/bin.rb
@@ -128,7 +128,7 @@ class PuppetLint::Bin
         end
 
         if PuppetLint.configuration.fix
-          File.open(f, 'w') do |fd|
+          File.open(f, 'wb') do |fd|
             fd.puts l.manifest
           end
         end


### PR DESCRIPTION
It's pretty annoying to have all LF lines switch to CRLF when using the new -f switch. Given I don't know ruby at all, I am not sure if this has other implications regarding file encoding and such, but I would imagine writing out the bytes as is is alright.
