### PR TITLE
Lone dollar sign should not be removed

### DIFF
--- a/spec/puppet-lint/plugins/check_strings/double_quoted_strings_spec.rb
+++ b/spec/puppet-lint/plugins/check_strings/double_quoted_strings_spec.rb
@@ -24,6 +24,23 @@ describe 'double_quoted_strings' do
     }
   end
 
+  describe 'double quoted string containing a lone dollar w/fix' do
+    before do
+      PuppetLint.configuration.fix = true
+    end
+
+    after do
+      PuppetLint.configuration.fix = false
+    end
+
+    let(:code) {"\"sed -i 's/^;*[[:space:]]*${name}[[:space:]]*=.*$/${name} = ${value}/g' file\"" }
+
+    its(:problems) { should be_empty }
+    its(:manifest) {
+      should == "\"sed -i 's/^;*[[:space:]]*${name}[[:space:]]*=.*$/${name} = ${value}/g' file\""
+    }
+  end
+
   describe 'multiple strings in a line' do
     let(:code) { "\"aoeu\" '${foo}'" }
 


### PR DESCRIPTION
This is just a failing test to describe a problem I noticed. The `$` (end-delimiter) in the sed match regex gets removed by the fix command. I couldn't figure out how to fix it unfortunately.
