### PR TITLE
Change single quoted strings that contain variables check to a warning.

### DIFF
--- a/lib/puppet-lint/plugins/check_strings.rb
+++ b/lib/puppet-lint/plugins/check_strings.rb
@@ -62,14 +62,14 @@ class PuppetLint::Plugins::CheckStrings < PuppetLint::CheckPlugin
   end
 
   # Public: Check the manifest tokens for any single quoted strings containing
-  # a enclosed variable and record an error for each instance found.
+  # an enclosed variable and record a warning for each instance found.
   #
   # Returns nothing.
   check 'single_quote_string_with_variables' do
     tokens.select { |r|
       r.type == :SSTRING && r.value.include?('${')
     }.each do |token|
-      notify :error, {
+      notify :warning, {
         :message    => 'single quoted string containing a variable found',
         :linenumber => token.line,
         :column     => token.column,

--- a/spec/puppet-lint/plugins/check_strings/single_quote_string_with_variables_spec.rb
+++ b/spec/puppet-lint/plugins/check_strings/single_quote_string_with_variables_spec.rb
@@ -6,7 +6,7 @@ describe 'single_quote_string_with_variables' do
 
     its(:problems) {
       should have_problem({
-        :kind       => :error,
+        :kind       => :warning,
         :message    => 'single quoted string containing a variable found',
         :linenumber => 1,
         :column     => 8,


### PR DESCRIPTION
This is actually not a MUST in a styleguide and there are legitimate
reasons where single quoted strings might contain the string '${'.
Anything to do with shell variables is a prime example:

``` shell
'some command "${variable}"'
```

or for fancier things

``` shell
'some command "${variable:"default"}"'
```

Still probably a good idea to warn people about potential issue, so warnings.
