### PR TITLE
fixed wrong link for "class inheriting from params class" check

### DIFF
--- a/checks/index.md
+++ b/checks/index.md
@@ -52,7 +52,7 @@ how to resolve it.
  * ["top-scope variable being used without an explicit namespace"](/checks/variable_scope/)
  * ["variable contains a dash"](/checks/variable_contains_dash/)
  * ["optional parameter listed before required parameter"](/checks/parameter_order/)
- * ["class inheriting from params class"](/checks/class_parameter_defaults/)
+ * ["class inheriting from params class"](/checks/class_inherits_from_params_class/)
  * ["parameterised class parameter without a default value"](/checks/class_parameter_defaults/)
  * ["foo::bar-baz contains a dash"](/checks/names_containing_dash/)
 


### PR DESCRIPTION
Hi!
Here's a fix for wrong link on Checks page for "class inheriting from params class" check.
