### PR TITLE
Don't warn about 'mode' format when it's an 'audit' value

### DIFF
--- a/lib/puppet-lint/plugins/check_resources.rb
+++ b/lib/puppet-lint/plugins/check_resources.rb
@@ -135,6 +135,8 @@ class PuppetLint::Plugins::CheckResources < PuppetLint::CheckPlugin
         resource_tokens.select { |resource_token|
           resource_token.type == :NAME and resource_token.value == 'mode'
         }.each do |resource_token|
+          break unless resource_token.next_code_token.type == :FARROW
+
           value_token = resource_token.next_code_token.next_code_token
 
           break if value_token.value =~ /\A[0-7]{4}\Z/

--- a/spec/puppet-lint/plugins/check_resources/file_mode_spec.rb
+++ b/spec/puppet-lint/plugins/check_resources/file_mode_spec.rb
@@ -40,4 +40,10 @@ describe 'file_mode' do
       should only_have_problem :kind => :warning, :message => "mode should be represented as a 4 digit octal value or symbolic mode", :linenumber => 1
     }
   end
+
+  describe 'mode as audit value' do
+    let(:code) { "file { '/etc/passwd': audit => [ owner, mode ], }" }
+
+    its(:problems) { should be_empty }
+  end
 end


### PR DESCRIPTION
The following code:

``` puppet
file { '/etc/passwd':
  audit => [ owner, mode ],
}
```

generates a bogus warning from puppet-lint:

```
WARNING: mode should be represented as a 4 digit octal value or symbolic mode on line 2
```
