### PR TITLE
Warn about unquoted node names

### DIFF
--- a/lib/puppet-lint/plugins.rb
+++ b/lib/puppet-lint/plugins.rb
@@ -51,5 +51,6 @@ require 'puppet-lint/plugins/check_strings'
 require 'puppet-lint/plugins/check_variables'
 require 'puppet-lint/plugins/check_whitespace'
 require 'puppet-lint/plugins/check_resources'
+require 'puppet-lint/plugins/check_nodes'
 
 PuppetLint::Plugins.load_from_gems

--- a/lib/puppet-lint/plugins/check_nodes.rb
+++ b/lib/puppet-lint/plugins/check_nodes.rb
@@ -1,0 +1,19 @@
+class PuppetLint::Plugins::CheckNodes < PuppetLint::CheckPlugin
+  # Check the manifest for unquoted node names and warn if found.
+  #
+  # Returns nothing.
+  check 'unquoted_node_name' do
+    tokens.select { |r|
+      r.type == :NODE && r.next_code_token.type == :NAME
+    }.each do |token|
+      value_token = token.next_code_token
+      unless value_token.value == 'default'
+        notify :warning, {
+          :message    => 'unquoted node name found',
+          :linenumber => value_token.line,
+          :column     => value_token.column,
+        }
+      end
+    end
+  end
+end

--- a/spec/puppet-lint/plugins/check_nodes/unquoted_node_name_spec.rb
+++ b/spec/puppet-lint/plugins/check_nodes/unquoted_node_name_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+
+describe 'unquoted_node_name' do
+  describe 'unquoted node name' do
+    let(:code) { "node foo { }" }
+
+    its(:problems) {
+      should have_problem({
+        :kind       => :warning,
+        :message    => 'unquoted node name found',
+        :linenumber => 1,
+        :column     => 6,
+      })
+    }
+  end
+
+  describe 'default node' do
+    let(:code) { "node default { }" }
+
+    its(:problems) { should be_empty }
+  end
+
+  describe 'single quoted node name' do
+    let(:code) { "node 'foo' { }" }
+
+    its(:problems) { should be_empty }
+  end
+
+  describe 'regex node name' do
+    let(:code) { "node /foo/ { }" }
+
+    its(:problems) { should be_empty }
+  end
+end


### PR DESCRIPTION
According to the Language Reference:

"A node statement’s name must be one of the following:
- A quoted string
- The bare word default
- A regular expression"

http://docs.puppetlabs.com/puppet/3/reference/lang_node_definitions.html

But puppet-lint doesn't complain if your node names are unquoted. For example:

```
node server1 {
  ...
}
```

while still accepted by Puppet, does not conform to the Language Reference rules. I'd like to see puppet-lint warn you, perhaps by saying:

WARNING: unquoted node name on line 1
