### PR TITLE
Add check for puppet:/// URIs without modules/

### DIFF
--- a/lib/puppet-lint/plugins/check_strings.rb
+++ b/lib/puppet-lint/plugins/check_strings.rb
@@ -93,4 +93,23 @@ class PuppetLint::Plugins::CheckStrings < PuppetLint::CheckPlugin
       }
     end
   end
+
+  # Public: Check the manifest tokens for any puppet:// URL strings where the
+  # path section doesn't start with modules/ and record a warning for each
+  # instance found.
+  #
+  # Returns nothing.
+  check 'puppet_url_without_modules' do
+    tokens.select { |token|
+      token.type == :SSTRING && token.value.start_with?('puppet://')
+    }.reject { |token|
+      token.value[/puppet:\/\/.*?\/(.+)/, 1].start_with?('modules/')
+    }.each do |token|
+      notify :warning, {
+        :message    => 'puppet:// URL without modules/ found',
+        :linenumber => token.line,
+        :column     => token.column,
+      }
+    end
+  end
 end

--- a/spec/puppet-lint/plugins/check_strings/puppet_url_without_modules_spec.rb
+++ b/spec/puppet-lint/plugins/check_strings/puppet_url_without_modules_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+describe 'puppet_url_without_modules' do
+  describe 'puppet:// url with modules' do
+    let(:code) { "'puppet:///modules/foo'" }
+
+    its(:problems) { should be_empty }
+  end
+
+  describe 'puppet:// url without modules' do
+    let(:code) { "'puppet:///foo'" }
+
+    its(:problems) do
+      should only_have_problem({
+        :kind       => :warning,
+        :message    => 'puppet:// URL without modules/ found',
+        :linenumber => 1,
+        :column     => 1,
+      })
+    end
+  end
+end


### PR DESCRIPTION
This will throw false positives for people who use custom fileserver mount points, but people using those probably already use the modules mount point correctly and can disable the check.  This is for folk who didn't see the deprecation notices in 2.6 and 2.7.
