### PR TITLE
Checks for code outside class/define block

### DIFF
--- a/lib/puppet-lint/plugins/check_classes.rb
+++ b/lib/puppet-lint/plugins/check_classes.rb
@@ -170,6 +170,24 @@ PuppetLint.new_check(:nested_classes_or_defines) do
   end
 end
 
+# Public: Test that no code is outside of a class or define scope.
+PuppetLint.new_check(:code_on_top_scope) do
+  def check
+    class_scope = (class_indexes + defined_type_indexes).map { |e| tokens[e[:start]..e[:end]] }.flatten
+    top_scope   = tokens - class_scope
+
+    top_scope.each do |token|
+      unless formatting_tokens.include? token.type
+        notify :warning, {
+          :message    => "code outside of class or define block - #{token.value}",
+          :linenumber => token.line,
+          :column     => token.column
+        }
+      end
+    end
+  end
+end
+
 # Public: Test the manifest tokens for any variables that are referenced in
 # the manifest.  If the variables are not fully qualified or one of the
 # variables automatically created in the scope, check that they have been

--- a/spec/puppet-lint/plugins/check_classes/code_on_top_scope_spec.rb
+++ b/spec/puppet-lint/plugins/check_classes/code_on_top_scope_spec.rb
@@ -1,0 +1,44 @@
+require 'spec_helper'
+
+describe 'code_on_top_scope' do
+  describe 'comments outside class block' do
+    let(:code) { "
+      # Baz
+      class foo:bar {
+      }"
+    }
+
+    its(:problems) { should be_empty }
+  end
+
+  describe 'new lines outside of class-define block' do
+    let(:code) { "
+
+      class foo:bar {
+      }
+
+      "
+    }
+
+    its(:problems) { should be_empty }
+  end
+  describe 'code outside class block' do
+    let(:code) { "
+      include('something')
+
+      # Baz
+      class foo:bar {
+      }
+
+      define whatever {
+      }"
+    }
+
+    its(:problems) {
+      should have_problem({
+        :kind       => :warning,
+        :message    => "code outside of class or define block - include",
+      })
+      should_not have_problem :kind => :error  }
+  end
+end


### PR DESCRIPTION
Code outside class or define blocks should go in different files
according to the puppet guide.
http://docs.puppetlabs.com/guides/style_guide.html#separate-files

Not only that but it can also trigger nasty bugs as mentioned in issue
https://github.com/rodjek/puppet-lint/issues/220