### PR TITLE
Running with --fix deletes all code for files containing invalid syntax

### DIFF
--- a/lib/puppet-lint/bin.rb
+++ b/lib/puppet-lint/bin.rb
@@ -127,7 +127,7 @@ class PuppetLint::Bin
           return_val = 1
         end
 
-        if PuppetLint.configuration.fix
+        if PuppetLint.configuration.fix && !l.errors.any? { |e| e[:check] == :syntax }
           File.open(f, 'w') do |fd|
             fd.puts l.manifest
           end

--- a/lib/puppet-lint/checks.rb
+++ b/lib/puppet-lint/checks.rb
@@ -56,9 +56,10 @@ class PuppetLint::Checks
       @tokens = lexer.tokenise(data)
     rescue PuppetLint::LexerError => e
       notify :error, {
-        :message => 'Syntax error (try running `puppet parser validate <file>`)',
+        :check      => :syntax,
+        :message    => 'Syntax error (try running `puppet parser validate <file>`)',
         :linenumber => e.line_no,
-        :column => e.column,
+        :column     => e.column,
       }
       @tokens = []
     end


### PR DESCRIPTION
Related to #183 .  `puppet-lint --fix` on files containing invalid puppet code will delete all code from the file.  It seems like you should probably do nothing to files with invalid syntax, rather then deleting everything.
