### PR TITLE
--fix doesn't modify my file

### DIFF
--- a/lib/puppet-lint/plugins.rb
+++ b/lib/puppet-lint/plugins.rb
@@ -28,13 +28,13 @@ class PuppetLint
     def self.gem_directories
       if has_rubygems?
         if Gem::Specification.respond_to? :latest_specs
-          Gem::Specification.latest_specs.map do |spec|
-            Pathname.new(spec.full_gem_path) + 'lib'
-          end
+          specs = Gem::Specification.latest_specs
         else
-          Gem.searcher.init_gemspecs.map do |spec|
-            Pathname.new(spec.full_gem_path) + 'lib'
-          end
+          specs = Gem.searcher.init_gemspecs
+        end
+
+        specs.reject { |spec| spec.name == 'puppet-lint' }.map do |spec|
+          Pathname.new(spec.full_gem_path) + 'lib'
         end
       else
         []


### PR DESCRIPTION
I imagine I'm doing something wrong here, but I'm not sure what:

```
$ gem install --pre puppet-lint -v 0.4.0.pre1
Fetching: puppet-lint-0.4.0.pre1.gem (100%)
Successfully installed puppet-lint-0.4.0.pre1
1 gem installed
Installing ri documentation for puppet-lint-0.4.0.pre1...
Installing RDoc documentation for puppet-lint-0.4.0.pre1...
$ puppet-lint --version
Puppet-lint 0.4.0.pre1
$ puppet-lint -f file.pp
WARNING: class not documented on line 1
ERROR: tab character found on line 17
ERROR: tab character found on line 19
ERROR: trailing whitespace found on line 14
ERROR: two-space soft tabs not used on line 17
ERROR: two-space soft tabs not used on line 19
WARNING: indentation of => is not properly aligned on line 17
$ puppet-lint --fix file.pp
WARNING: class not documented on line 1
ERROR: tab character found on line 17
ERROR: tab character found on line 19
ERROR: trailing whitespace found on line 14
ERROR: two-space soft tabs not used on line 17
ERROR: two-space soft tabs not used on line 19
WARNING: indentation of => is not properly aligned on line 17
$ svn diff
$
```

In short, nothing's being changed in my input file.  I'll attach the input so you can see what I'm doing (in short: there's plenty wrong with it).
