### PR TITLE
Allow double quotes for puppet supported escape sequences

### DIFF
--- a/lib/puppet-lint/plugins/check_strings.rb
+++ b/lib/puppet-lint/plugins/check_strings.rb
@@ -8,7 +8,7 @@ PuppetLint.new_check(:double_quoted_strings) do
     }.each { |r|
       r.value.gsub!(' '*r.column, "\n")
     }.select { |r|
-      r.value[/(\t|\\t|\n|\\n)/].nil?
+      r.value[/(\\\$|\\"|\\'|\r|\t|\\t|\n|\\n)/].nil?
     }.each do |token|
       notify :warning, {
         :message    => 'double quoted string containing no variables',

--- a/spec/puppet-lint/plugins/check_strings/double_quoted_strings_spec.rb
+++ b/spec/puppet-lint/plugins/check_strings/double_quoted_strings_spec.rb
@@ -88,10 +88,28 @@ describe 'double_quoted_strings' do
     its(:problems) { should be_empty }
   end
 
-  describe 'double quoted string containing newline but no variables' do
-    let(:code) { %{"foo\n"} }
+  describe 'double quoted stings containing supported escape patterns' do
+    let(:code) {%{
+      $string1 = "this string contins \n newline"
+      $string2 = "this string contains \ttab"
+      $string3 = "this string contains \${escaped} var"
+      $string4 = "this string contains \\"escaped \\" double quotes"
+      $string5 = "this string contains \\'escaped \\' single quotes"
+      $string6 = "this string contains \r line return"
+      }}
+    its (:problems) { should == [] }
+  end
 
-    its(:problems) { should be_empty }
+  describe 'double quoted string with random escape should be rejected' do
+    let(:code) {%{ $ztring = "this string contains \l random esape" } }
+    its (:problems) {
+      should have_problem({
+        :kind       => :warning,
+        :message    => 'double quoted string containing no variables',
+        :linenumber => 1,
+        :column     => 12,
+      })
+    }
   end
 
   describe 'double quoted string with backslash for continuation' do


### PR DESCRIPTION
add support for \$ \" \' \r (\t \n already supported) escape
sequences.

This is to follow:
 http://docs.puppetlabs.com/puppet/2.7/reference/lang_datatypes.html#double-quoted-strings

While puppet supports \\ and \s, both are replaced with normal characters
that lint otherwise should look for.

These are necessary to support confusing escape sequens that end up being
passed to downstream commands and the like. Making propper use double
quotes but preventing lint from generating false warnings.

Signed-off-by: Andrew Woodward awoodward@mirantis.com
