### PR TITLE
Added a new check that issues a warning when the user field instead of t...

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,22 @@ Placeholder
 
 Placeholder
 
+### user_instead_of_owner
+
+Checks if the 'user' field is set on a file resource (should be 'owner')
+
+Bad:
+
+```
+file { 'foo': user => :root }
+```
+
+Good:
+
+```
+file { 'foo': owner => :root }
+```
+
 ### 4digit_file_mode
 
 Placeholder

--- a/lib/puppet-lint/plugins/check_resources.rb
+++ b/lib/puppet-lint/plugins/check_resources.rb
@@ -206,3 +206,30 @@ PuppetLint.new_check(:ensure_not_symlink_target) do
     end
   end
 end
+
+PuppetLint.new_check(:user_instead_of_owner) do
+  def check
+    resource_indexes.each do |resource|
+      resource_tokens = tokens[resource[:start]..resource[:end]]
+      prev_tokens = tokens[0..resource[:start]]
+
+      lbrace_idx = prev_tokens.rindex { |r|
+        r.type == :LBRACE
+      }
+
+      resource_type_token = tokens[lbrace_idx].prev_code_token
+      if resource_type_token.value == "file"
+        resource_tokens.select { |resource_token|
+          resource_token.type == :NAME and resource_token.value == 'user'
+        }.each do |resource_token|
+          notify :warning, {
+            :message    => 'file resource doesn\'t use user field; use owner instead',
+            :linenumber => resource_token.line,
+            :column     => resource_token.column,
+            :token      => resource_token,
+          }
+        end
+      end
+    end
+  end
+end

--- a/spec/puppet-lint/plugins/check_resources/file_owner_spec.rb
+++ b/spec/puppet-lint/plugins/check_resources/file_owner_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+describe 'user_instead_of_owner' do
+  describe 'user field should cause a warning' do
+    let(:code) { "file { 'foo': user => :root }" }
+
+    its(:problems) do
+      should only_have_problem({
+        :kind       => :warning,
+        :message    => "file resource doesn't use user field; use owner instead",
+        :linenumber => 1,
+        :column     => 15,
+      })
+    end
+  end
+
+  describe 'owner field should not cause a problem' do
+    let(:code) { "file { 'foo': owner => :root }" }
+
+    its(:problems) do
+      should be_empty
+    end
+  end
+
+  describe 'user and owner should still cause a warning' do
+    let(:code) { "file { 'foo': user => :root, owner => :root }" }
+
+    its(:problems) do
+      should only_have_problem({
+        :kind       => :warning,
+        :message    => "file resource doesn't use user field; use owner instead",
+        :linenumber => 1,
+        :column     => 15,
+      })
+    end
+  end
+end


### PR DESCRIPTION
This will add a new check that will issue a warning whenever the user attribute is used instead of the owner attribute for file resources; which unfortunately is a common trap. 
