### PR TITLE
Fixes https://github.com/rodjek/puppet-lint/issues/249 - Variables incorrectly identified as top scope

### DIFF
--- a/lib/puppet-lint/plugins/check_classes.rb
+++ b/lib/puppet-lint/plugins/check_classes.rb
@@ -228,7 +228,7 @@ PuppetLint.new_check(:variable_scope) do
 
       object_tokens.each do |token|
         if token.type == :VARIABLE
-          if token.next_code_token.type == :EQUALS
+          if token.next_code_token.type == :EQUALS or token.next_code_token.type == :PIPE
             variables_in_scope << token.value
           else
             referenced_variables << token

--- a/spec/puppet-lint/plugins/check_classes/variable_scope_spec.rb
+++ b/spec/puppet-lint/plugins/check_classes/variable_scope_spec.rb
@@ -112,4 +112,23 @@ describe 'variable_scope' do
       expect(problems).to have(0).problems
     end
   end
+
+
+  context 'define with for each loops' do
+    let(:code) { "
+      define foreach ()
+        $array = [ 'bar', 'moo' ]
+        $array.each |$a| {
+        }
+
+        $hash = { 'a' => 100, 'b' => 200 }
+        $hash.each |$k, $v| {
+        }
+      }"
+    }
+
+    it 'should not detect any problems' do
+      expect(problems).to have(0).problems
+    end
+  end
 end


### PR DESCRIPTION
This affects when parser = future and we are utilising the $foo.each |$var| loops that gives us puppet-lint will throw a warning saying that we are referencing a top scope variable (when in fact we are not).

Not being a puppet-lint pro here, the change i've done seems to circumvent that issue, and i've also added a test for it
