### PR TITLE
Use #write instead of #puts when writing fixed manifest

### DIFF
--- a/lib/puppet-lint/bin.rb
+++ b/lib/puppet-lint/bin.rb
@@ -54,7 +54,7 @@ class PuppetLint::Bin
 
         if PuppetLint.configuration.fix && !l.problems.any? { |e| e[:check] == :syntax }
           File.open(f, 'w') do |fd|
-            fd.puts l.manifest
+            fd.write l.manifest
           end
         end
       end


### PR DESCRIPTION
So we write the manifest back in it's original form, without adding a trailing newline if one didn't already exist.
