### PR TITLE
Make array refs part of the variable name

### DIFF
--- a/lib/puppet-lint/lexer.rb
+++ b/lib/puppet-lint/lexer.rb
@@ -165,7 +165,7 @@ class PuppetLint
         end
 
         unless found
-          if var_name = chunk[/\A\$((::)?([\w-]+::)*[\w-]+)/, 1]
+          if var_name = chunk[/\A\$((::)?([\w-]+::)*[\w-]+([\[\w-]+\])*)/, 1]
             tokens << new_token(:VARIABLE, var_name, :chunk => code[0..i])
             i += var_name.size + 1
 
@@ -356,7 +356,7 @@ class PuppetLint
             end
           else
             contents = ss.scan_until(/\}/)[0..-2]
-            if contents.match(/\A(::)?([\w-]+::)*[\w-]+/)
+            if contents.match(/\A(::)?([\w-]+::)*[\w-]+([\[\w-]+\])*/)
               contents = "$#{contents}"
             end
             lexer = PuppetLint::Lexer.new

--- a/spec/puppet-lint/lexer_spec.rb
+++ b/spec/puppet-lint/lexer_spec.rb
@@ -182,6 +182,28 @@ describe PuppetLint::Lexer do
       expect(tokens[2].column).to eq(8)
     end
 
+    it 'should handle a variable with an array reference' do
+      @lexer.interpolate_string('${foo[bar][baz]}"', 1, 1)
+      tokens = @lexer.tokens
+
+      expect(tokens.length).to eq(3)
+
+      expect(tokens[0].type).to eq(:DQPRE)
+      expect(tokens[0].value).to eq('')
+      expect(tokens[0].line).to eq(1)
+      expect(tokens[0].column).to eq(1)
+
+      expect(tokens[1].type).to eq(:VARIABLE)
+      expect(tokens[1].value).to eq('foo[bar][baz]')
+      expect(tokens[1].line).to eq(1)
+      expect(tokens[1].column).to eq(3)
+
+      expect(tokens[2].type).to eq(:DQPOST)
+      expect(tokens[2].value).to eq('')
+      expect(tokens[2].line).to eq(1)
+      expect(tokens[2].column).to eq(18)
+    end
+
     it 'should handle a string with only many variables' do
       @lexer.interpolate_string('${bar}${gronk}"', 1, 1)
       tokens = @lexer.tokens
@@ -310,6 +332,7 @@ describe PuppetLint::Lexer do
       @lexer.interpolate_string(%q{string with ${['an array ', $v2]} in it"}, 1, 1)
       tokens = @lexer.tokens
 
+      p tokens
       expect(tokens.length).to eq(8)
 
       expect(tokens[0].type).to eq(:DQPRE)


### PR DESCRIPTION
This changes is so that manifests like `$foo[bar]` gets tokenised as a single `:VARIABLE` token rather than an array of [`:VARIABLE`, `:LBRACK`, `:NAME`, `:RBRACK`].
