### PR TITLE
Automatically fix ensure_not_symlink_target problems

### DIFF
--- a/lib/puppet-lint/plugins/check_resources.rb
+++ b/lib/puppet-lint/plugins/check_resources.rb
@@ -168,13 +168,32 @@ PuppetLint.new_check(:ensure_not_symlink_target) do
           value_token = ensure_token.next_code_token.next_code_token
           if value_token.value.start_with? '/'
             notify :warning, {
-              :message => 'symlink target specified in ensure attr',
-              :line    => value_token.line,
-              :column  => value_token.column,
+              :message     => 'symlink target specified in ensure attr',
+              :line        => value_token.line,
+              :column      => value_token.column,
+              :param_token => ensure_token,
+              :value_token => value_token,
             }
           end
         end
       end
+    end
+  end
+
+  def fix(problem)
+    index = tokens.index(problem[:value_token])
+
+    [
+      PuppetLint::Lexer::Token.new(:NAME, 'symlink', 0, 0),
+      PuppetLint::Lexer::Token.new(:COMMA, ',', 0, 0),
+      PuppetLint::Lexer::Token.new(:NEWLINE, "\n", 0, 0),
+      PuppetLint::Lexer::Token.new(:INDENT, problem[:param_token].prev_token.value.dup, 0, 0),
+      PuppetLint::Lexer::Token.new(:NAME, 'target', 0, 0),
+      PuppetLint::Lexer::Token.new(:WHITESPACE, problem[:param_token].next_token.value.dup, 0, 0),
+      PuppetLint::Lexer::Token.new(:FARROW, '=>', 0, 0),
+      PuppetLint::Lexer::Token.new(:WHITESPACE, ' ', 0, 0),
+    ].reverse.each do |new_token|
+      tokens.insert(index, new_token)
     end
   end
 end

--- a/spec/puppet-lint/plugins/check_resources/ensure_not_symlink_target_spec.rb
+++ b/spec/puppet-lint/plugins/check_resources/ensure_not_symlink_target_spec.rb
@@ -3,32 +3,87 @@ require 'spec_helper'
 describe 'ensure_not_symlink_target' do
   let(:msg) { 'symlink target specified in ensure attr' }
 
-  context 'file resource creating a symlink with seperate target attr' do
-    let(:code) { "
-      file { 'foo':
-        ensure => link,
-        target => '/foo/bar',
-      }"
-    }
+  context 'with fix disabled' do
+    context 'file resource creating a symlink with seperate target attr' do
+      let(:code) { "
+        file { 'foo':
+          ensure => link,
+          target => '/foo/bar',
+        }"
+      }
 
-    it 'should not detect any problems' do
-      expect(problems).to have(0).problems
+      it 'should not detect any problems' do
+        expect(problems).to have(0).problems
+      end
+    end
+
+    context 'file resource creating a symlink with target specified in ensure' do
+      let(:code) { "
+        file { 'foo':
+          ensure => '/foo/bar',
+        }"
+      }
+
+      it 'should only detect a single problem' do
+        expect(problems).to have(1).problem
+      end
+
+      it 'should create a warning' do
+        expect(problems).to contain_warning(msg).on_line(3).in_column(21)
+      end
     end
   end
 
-  context 'file resource creating a symlink with target specified in ensure' do
-    let(:code) { "
-      file { 'foo':
-        ensure => '/foo/bar',
-      }"
-    }
-
-    it 'should only detect a single problem' do
-      expect(problems).to have(1).problem
+  context 'with fix enabled' do
+    before do
+      PuppetLint.configuration.fix = true
     end
 
-    it 'should create a warning' do
-      expect(problems).to contain_warning(msg).on_line(3).in_column(19)
+    after do
+      PuppetLint.configuration.fix = false
+    end
+
+    context 'file resource creating a symlink with seperate target attr' do
+      let(:code) { "
+        file { 'foo':
+          ensure => link,
+          target => '/foo/bar',
+        }"
+      }
+
+      it 'should not detect any problems' do
+        expect(problems).to have(0).problems
+      end
+
+      it 'should not modify the manifest' do
+        expect(manifest).to eq(code)
+      end
+    end
+
+    context 'file resource creating a symlink with target specified in ensure' do
+      let(:code) { "
+        file { 'foo':
+          ensure => '/foo/bar',
+        }"
+      }
+      let(:fixed) { "
+        file { 'foo':
+          ensure => symlink,
+          target => '/foo/bar',
+        }"
+      }
+
+      it 'should only detect a single problem' do
+        expect(problems).to have(1).problem
+      end
+
+      it 'should fix the problem' do
+        expect(problems).to contain_fixed(msg).on_line(3).in_column(21)
+      end
+
+      it 'should create a new target param' do
+        expect(manifest).to eq(fixed)
+      end
     end
   end
 end


### PR DESCRIPTION
With `--fix` specified, it'll set `ensure => symlink` and create a line directly below `ensure` with `target => <old ensure value>`.
