### PR TITLE
Automatically convert multiline comments into many single line comments

### DIFF
--- a/lib/puppet-lint/plugins/check_comments.rb
+++ b/lib/puppet-lint/plugins/check_comments.rb
@@ -30,7 +30,26 @@ PuppetLint.new_check(:star_comments) do
         :message => '/* */ comment found',
         :line    => token.line,
         :column  => token.column,
+        :token   => token,
       }
+    end
+  end
+
+  def fix(problem)
+    comment_lines = problem[:token].value.split("\n")
+    first_line = comment_lines.shift
+    problem[:token].type = :COMMENT
+    problem[:token].value = " #{first_line}"
+
+    index = tokens.index(problem[:token].next_token)
+    comment_lines.reverse.each do |line|
+      [
+        PuppetLint::Lexer::Token.new(:COMMENT, " #{line}", 0, 0),
+        PuppetLint::Lexer::Token.new(:INDENT, problem[:token].prev_token.value.dup, 0, 0),
+        PuppetLint::Lexer::Token.new(:NEWLINE, "\n", 0, 0),
+      ].each do |new_token|
+        tokens.insert(index, new_token)
+      end
     end
   end
 end

--- a/spec/puppet-lint/plugins/check_comments/star_comments_spec.rb
+++ b/spec/puppet-lint/plugins/check_comments/star_comments_spec.rb
@@ -3,18 +3,82 @@ require 'spec_helper'
 describe 'star_comments' do
   let(:msg) { '/* */ comment found' }
 
-  context 'slash asterisk comment' do
-    let(:code) { "
-      /* foo
-      */
-    "}
+  context 'with fix disabled' do
+    context 'multiline comment w/ one line of content' do
+      let(:code) { "
+        /* foo
+        */
+      "}
 
-    it 'should only detect a single problem' do
-      expect(problems).to have(1).problem
+      it 'should only detect a single problem' do
+        expect(problems).to have(1).problem
+      end
+
+      it 'should create a warning' do
+        expect(problems).to contain_warning(msg).on_line(2).in_column(9)
+      end
+    end
+  end
+
+  context 'with fix enabled' do
+    before do
+      PuppetLint.configuration.fix = true
     end
 
-    it 'should create a warning' do
-      expect(problems).to contain_warning(msg).on_line(2).in_column(7)
+    after do
+      PuppetLint.configuration.fix = false
+    end
+
+    context 'multiline comment w/ one line of content' do
+      let(:code) { "
+        /* foo
+        */
+      "}
+
+      let(:fixed) { "
+        # foo
+      "}
+
+      it 'should only detect a single problem' do
+        expect(problems).to have(1).problem
+      end
+
+      it 'should create a warning' do
+        expect(problems).to contain_fixed(msg).on_line(2).in_column(9)
+      end
+
+      it 'should convert the multiline comment' do
+        expect(manifest).to eq(fixed)
+      end
+    end
+
+    context 'multiline comment w/ multiple line of content' do
+      let(:code) { "
+        /* foo
+         * bar
+         * baz
+         */
+        notify { 'foo': }
+      "}
+
+      let(:fixed) { "
+        # foo
+        # bar
+        # baz
+        notify { 'foo': }
+      "}
+
+      it 'should only detect a single problem' do
+        expect(problems).to have(1).problem
+      end
+
+      it 'should create a warning' do
+        expect(problems).to contain_fixed(msg).on_line(2).in_column(9)
+      end
+
+      it 'should convert the multiline comment' do
+        expect(manifest).to eq(fixed)
+      end
     end
   end
 end


### PR DESCRIPTION
With `--fix` enabled, puppet-lint will convert

``` puppet
class foo {
  /* this is a really long description
   * of something
   */
  notify { 'whatever': }
}
```

into

``` puppet
class foo {
  # this is a really long description
  # of something
  notify { 'whatever': }
}
```
