### PR TITLE
Throw :error instead of :warning for class names containing hyphens

### DIFF
--- a/lib/puppet-lint/plugins/check_classes.rb
+++ b/lib/puppet-lint/plugins/check_classes.rb
@@ -45,22 +45,32 @@ PuppetLint.new_check(:autoloader_layout) do
   end
 end
 
-# Public: Check the manifest tokens for any classes or defined types that
-# have a dash in their name and record a warning for each instance found.
-PuppetLint.new_check(:names_containing_dash) do
+# Public: Check the manifest tokens for any classes that
+# have a dash in their name and record an error for each instance found.
+PuppetLint.new_check(:class_names_containing_dash) do
   def check
-    (class_indexes + defined_type_indexes).each do |class_idx|
+    (class_indexes).each do |class_idx|
       if class_idx[:name_token].value.include? '-'
-        if class_idx[:type] == :CLASS
-          obj_type = 'class'
-        else
-          obj_type = 'defined type'
-        end
-
-        notify :warning, {
-          :message => "#{obj_type} name containing a dash",
+        notify :error, {
+          :message => "class name containing a dash",
           :line    => class_idx[:name_token].line,
           :column  => class_idx[:name_token].column,
+        }
+      end
+    end
+  end
+end
+
+# Public: Check the manifest tokens for any defined types that
+# have a dash in their name and record a warning for each instance found.
+PuppetLint.new_check(:defined_type_names_containing_dash) do
+  def check
+    (defined_type_indexes).each do |class_idx|
+      if class_idx[:name_token].value.include? '-'
+        notify :warning, {
+            :message => "defined type name containing a dash",
+            :line    => class_idx[:name_token].line,
+            :column  => class_idx[:name_token].column,
         }
       end
     end

--- a/spec/puppet-lint/plugins/check_classes/class_names_containing_dash.rb
+++ b/spec/puppet-lint/plugins/check_classes/class_names_containing_dash.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'names_containing_dash' do
+describe 'class_names_containing_dash' do
   let(:class_msg) { 'class name containing a dash' }
   let(:define_msg) { 'defined type name containing a dash' }
 
@@ -12,21 +12,8 @@ describe 'names_containing_dash' do
       expect(problems).to have(1).problem
     end
 
-    it 'should create a warning' do
-      expect(problems).to contain_warning(class_msg).on_line(1).in_column(7)
-    end
-  end
-
-  context 'define named foo-bar' do
-    let(:code) { 'define foo::foo-bar { }' }
-    let(:path) { 'foo/manifests/foo-bar.pp' }
-
-    it 'should only detect a single problem' do
-      expect(problems).to have(1).problem
-    end
-
-    it 'should create a warning' do
-      expect(problems).to contain_warning(define_msg).on_line(1).in_column(8)
+    it 'should create an error' do
+      expect(problems).to contain_error(msg).on_line(1).in_column(7)
     end
   end
 
@@ -38,8 +25,8 @@ describe 'names_containing_dash' do
       expect(problems).to have(1).problem
     end
 
-    it 'should create a warning' do
-      expect(problems).to contain_warning(class_msg).on_line(1).in_column(7)
+    it 'should create an error' do
+      expect(problems).to contain_error(msg).on_line(1).in_column(7)
     end
   end
 end

--- a/spec/puppet-lint/plugins/check_classes/defined_type_names_containing_dash.rb
+++ b/spec/puppet-lint/plugins/check_classes/defined_type_names_containing_dash.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+describe 'defined_type_names_containing_dash' do
+  let(:class_msg) { 'class name containing a dash' }
+  let(:define_msg) { 'defined type name containing a dash' }
+
+  context 'define named foo-bar' do
+    let(:code) { 'define foo::foo-bar { }' }
+    let(:path) { 'foo/manifests/foo-bar.pp' }
+
+    it 'should only detect a single problem' do
+      expect(problems).to have(1).problem
+    end
+
+    it 'should create a warning' do
+      expect(problems).to contain_warning(define_msg).on_line(1).in_column(8)
+    end
+  end
+end


### PR DESCRIPTION
We've run into serious problems with `librarian-puppet` when a class name contained hyphens. Plus, it's a non-allowed char according to https://docs.puppetlabs.com/puppet/latest/reference/modules_fundamentals.html#allowed-module-names

Wouldn't it help to treat this as an `:error` thus letting linting fail?