### PR TITLE
Alternative to #289: :error on either class names and defines

### DIFF
--- a/lib/puppet-lint/plugins/check_classes.rb
+++ b/lib/puppet-lint/plugins/check_classes.rb
@@ -46,7 +46,7 @@ PuppetLint.new_check(:autoloader_layout) do
 end
 
 # Public: Check the manifest tokens for any classes or defined types that
-# have a dash in their name and record a warning for each instance found.
+# have a dash in their name and record an error for each instance found.
 PuppetLint.new_check(:names_containing_dash) do
   def check
     (class_indexes + defined_type_indexes).each do |class_idx|
@@ -57,7 +57,7 @@ PuppetLint.new_check(:names_containing_dash) do
           obj_type = 'defined type'
         end
 
-        notify :warning, {
+        notify :error, {
           :message => "#{obj_type} name containing a dash",
           :line    => class_idx[:name_token].line,
           :column  => class_idx[:name_token].column,

--- a/spec/puppet-lint/plugins/check_classes/names_containing_dash_spec.rb
+++ b/spec/puppet-lint/plugins/check_classes/names_containing_dash_spec.rb
@@ -12,8 +12,8 @@ describe 'names_containing_dash' do
       expect(problems).to have(1).problem
     end
 
-    it 'should create a warning' do
-      expect(problems).to contain_warning(class_msg).on_line(1).in_column(7)
+    it 'should create an error' do
+      expect(problems).to contain_error(class_msg).on_line(1).in_column(7)
     end
   end
 
@@ -25,8 +25,8 @@ describe 'names_containing_dash' do
       expect(problems).to have(1).problem
     end
 
-    it 'should create a warning' do
-      expect(problems).to contain_warning(define_msg).on_line(1).in_column(8)
+    it 'should create an error' do
+      expect(problems).to contain_error(define_msg).on_line(1).in_column(8)
     end
   end
 
@@ -38,8 +38,8 @@ describe 'names_containing_dash' do
       expect(problems).to have(1).problem
     end
 
-    it 'should create a warning' do
-      expect(problems).to contain_warning(class_msg).on_line(1).in_column(7)
+    it 'should create an error' do
+      expect(problems).to contain_error(class_msg).on_line(1).in_column(7)
     end
   end
 end


### PR DESCRIPTION
See #289  
closes #289 

Instead of differentiating between module/class names and defines, treat hyphens as an error in both

@rodjek Wdyt? May be it does not make sense to treat defines differently after all