### PR TITLE
Fix problems after all checks have finished

### DIFF
--- a/lib/puppet-lint/checkplugin.rb
+++ b/lib/puppet-lint/checkplugin.rb
@@ -12,12 +12,18 @@ class PuppetLint::CheckPlugin
         problem[:reason] = PuppetLint::Data.ignore_overrides[problem[:check]][problem[:line]]
         next
       end
+    end
 
-      if PuppetLint.configuration.fix && self.respond_to?(:fix)
+    @problems
+  end
+
+  def fix_problems
+    @problems.each do |problem|
+      if self.respond_to?(:fix)
         begin
           fix(problem)
         rescue PuppetLint::NoFix
-          # do nothing
+          # noop
         else
           problem[:kind] = :fixed
         end

--- a/lib/puppet-lint/checks.rb
+++ b/lib/puppet-lint/checks.rb
@@ -47,9 +47,20 @@ class PuppetLint::Checks
   def run(fileinfo, data)
     load_data(fileinfo, data)
 
+    checks_run = []
     enabled_checks.each do |check|
       klass = PuppetLint.configuration.check_object[check].new
-      @problems.concat(klass.run)
+      problems = klass.run
+
+      if PuppetLint.configuration.fix
+        checks_run << klass
+      else
+        @problems.concat(problems)
+      end
+    end
+
+    checks_run.each do |check|
+      @problems.concat(check.fix_problems)
     end
 
     @problems

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -107,7 +107,11 @@ module RSpec
       filepath = self.respond_to?(:path) ? path : ''
       klass.load_data(filepath, code)
       check_name = self.class.top_level_description.to_sym
-      klass.problems = PuppetLint.configuration.check_object[check_name].new.run
+      check = PuppetLint.configuration.check_object[check_name].new
+      klass.problems = check.run
+      if PuppetLint.configuration.fix
+        klass.problems = check.fix_problems
+      end
       klass
     end
   end


### PR DESCRIPTION
As the fix methods generally modify the `tokens` array, for safety lets ensure that they run after all the problems have been found.
