### PR TITLE
Support future parser loop local scope variables

### DIFF
--- a/spec/puppet-lint/plugins/check_classes/variable_scope_spec.rb
+++ b/spec/puppet-lint/plugins/check_classes/variable_scope_spec.rb
@@ -112,4 +112,26 @@ describe 'variable_scope' do
       expect(problems).to have(0).problems
     end
   end
+
+  context 'future parser blocks' do
+    let(:code) { "
+      class foo() {
+        $foo = [1,2]
+        $foo.each |$a, $b| {
+          $a
+          $c
+        }
+        $b
+      }
+    " }
+
+    it 'should only detect a single problem' do
+      expect(problems).to have(2).problem
+    end
+
+    it 'should create two warnings' do
+      expect(problems).to contain_warning(msg).on_line(8).in_column(9)
+      expect(problems).to contain_warning(msg).on_line(6).in_column(11)
+    end
+  end
 end


### PR DESCRIPTION
Adds support for future parser loop local scope blocks that define variables
to the variable_scope check.

Closes #264
Closes #258
Closes #249

/cc #271
