### PR TITLE
Insert :WHITESPACE token between :NAME and :FARROW if needed

### DIFF
--- a/lib/puppet-lint/plugins/check_whitespace.rb
+++ b/lib/puppet-lint/plugins/check_whitespace.rb
@@ -142,7 +142,13 @@ PuppetLint.new_check(:arrow_alignment) do
   end
 
   def fix(problem)
-    new_indent = ' ' * (problem[:indent_depth] - problem[:token].prev_token.column)
-    problem[:token].prev_token.value = new_indent
+    if problem[:token].prev_token.type == :WHITESPACE
+      new_indent = ' ' * (problem[:indent_depth] - problem[:token].prev_token.column)
+      problem[:token].prev_token.value = new_indent
+    else
+      index = tokens.index(problem[:token].prev_token)
+      whitespace = ' ' * (problem[:indent_depth] - problem[:token].column)
+      tokens.insert(index + 1, PuppetLint::Lexer::Token.new(:WHITESPACE, whitespace, 0, 0))
+    end
   end
 end

--- a/spec/puppet-lint/plugins/check_whitespace/arrow_alignment_spec.rb
+++ b/spec/puppet-lint/plugins/check_whitespace/arrow_alignment_spec.rb
@@ -399,5 +399,33 @@ describe 'arrow_alignment' do
         expect(manifest).to eq(fixed)
       end
     end
+
+    context 'resource with unaligned => and no whitespace between param and =>' do
+      let(:code) { "
+        user { 'test':
+          param1 => 'foo',
+          param2=> 'bar',
+        }
+      " }
+
+      let(:fixed) { "
+        user { 'test':
+          param1 => 'foo',
+          param2 => 'bar',
+        }
+      " }
+
+      it 'should detect 1 problem' do
+        expect(problems).to have(1).problem
+      end
+
+      it 'should fix the problem' do
+        expect(problems).to contain_fixed(msg).on_line(4).in_column(17)
+      end
+
+      it 'should add whitespace between the param and the arrow' do
+        expect(manifest).to eq(fixed)
+      end
+    end
   end
 end


### PR DESCRIPTION
When fixing arrow alignment, ensure that we insert a new :WHITESPACE token
if there isn't one there or we'll end up wiping out the parameter name when
fixing the arrow alignment.

Closes #311
