### PR TITLE
Don't parse class body when searching for parameter tokens

### DIFF
--- a/lib/puppet-lint/data.rb
+++ b/lib/puppet-lint/data.rb
@@ -255,6 +255,9 @@ class PuppetLint::Data
             rparen_idx = i
             break
           end
+        elsif token.type == :LBRACE && depth == 0
+          # no parameters
+          break
         end
       end
 


### PR DESCRIPTION
Fixes #319
