### PR TITLE
Don't warn for arrow alignment for single-element hashes

### DIFF
--- a/lib/puppet-lint/plugins/check_whitespace.rb
+++ b/lib/puppet-lint/plugins/check_whitespace.rb
@@ -124,7 +124,7 @@ PuppetLint.new_check(:arrow_alignment) do
           level_tokens[indent_depth_idx] ||= []
         elsif token.type == :RBRACE
           level_tokens[indent_depth_idx].each do |arrow_tok|
-            unless arrow_tok.column == indent_depth[indent_depth_idx]
+            unless arrow_tok.column == indent_depth[indent_depth_idx] || level_tokens[indent_depth_idx].size == 1
               arrows_on_line = level_tokens[indent_depth_idx].select { |t| t.line == arrow_tok.line }
               notify :warning, {
                 :message        => 'indentation of => is not properly aligned',

--- a/spec/puppet-lint/plugins/check_whitespace/arrow_alignment_spec.rb
+++ b/spec/puppet-lint/plugins/check_whitespace/arrow_alignment_spec.rb
@@ -268,6 +268,20 @@ describe 'arrow_alignment' do
         expect(problems).to contain_warning(msg).on_line(3).in_column(26)
       end
     end
+
+    context 'resource param containing a single-element same-line hash' do
+      let(:code) { "
+        foo { 'foo':
+          a => true,
+          b => { 'a' => 'b' }
+        }
+      "}
+
+      it 'should not detect any problems' do
+        expect(problems).to have(0).problems
+      end
+    end
+
   end
 
   context 'with fix enabled' do


### PR DESCRIPTION
Fixes #327