### PR TITLE
fix #331 - clear any pre-(auto-)existing tasks

### DIFF
--- a/lib/puppet-lint/tasks/puppet-lint.rb
+++ b/lib/puppet-lint/tasks/puppet-lint.rb
@@ -49,6 +49,8 @@ class PuppetLint
 
       task_block.call(*[self, args].slice(0, task_block.arity)) if task_block
 
+      # clear any (auto-)pre-existing task
+      Rake::Task[@name].clear
       task @name do
         PuppetLint::OptParser.build
 


### PR DESCRIPTION
Because we automatically create a lint task at the bottom of the file
using a configuration block with the default name (:lint) would not
work, as we would now have 2 instances of that RakeTask floating around.
However, only the first - auto-generated - task is used. Which makes
it impossible to configure any of the options for it.
