### PR TITLE
Catch Errno::EACCES when reading a puppet-lint.rc out of HOME

### DIFF
--- a/lib/puppet-lint/optparser.rb
+++ b/lib/puppet-lint/optparser.rb
@@ -98,7 +98,12 @@ class PuppetLint::OptParser
       end
 
       opts.load('/etc/puppet-lint.rc')
-      opts.load(File.expand_path('~/.puppet-lint.rc')) if ENV['HOME']
+      begin
+        opts.load(File.expand_path('~/.puppet-lint.rc')) if ENV['HOME']
+      rescue Errno::EACCES
+        # silently skip loading this file if HOME is set to a directory that
+        # the user doesn't have read access to.
+      end
       opts.load('.puppet-lint.rc')
     end
   end


### PR DESCRIPTION
Sometimes a user might not have access to read the directory set in the HOME environment variable, so we'll just silently fail when trying to check for and read a `puppet-lint.rc` file out of there.

Closes #337
