### PR TITLE
Do not create default rake task lint

### DIFF
--- a/lib/puppet-lint/tasks/puppet-lint.rb
+++ b/lib/puppet-lint/tasks/puppet-lint.rb
@@ -83,5 +83,3 @@ class PuppetLint
     end
   end
 end
-
-PuppetLint::RakeTask.new


### PR DESCRIPTION
Requiring the task file was enough to actually create the task.