### PR TITLE
rpearce: Allow the use of facts[] and trusted[] as per Puppet 3.5+

### DIFF
--- a/lib/puppet-lint/plugins/check_classes.rb
+++ b/lib/puppet-lint/plugins/check_classes.rb
@@ -267,13 +267,15 @@ PuppetLint.new_check(:variable_scope) do
         end
 
         unless token.value.include? '::'
-          unless variables_in_scope.include? token.value.gsub(/\[.+\]\Z/, '')
-            unless token.value =~ /\A\d+\Z/
-              notify :warning, {
-                :message => msg,
-                :line    => token.line,
-                :column  => token.column,
-              }
+          unless token.value =~ /^(facts|trusted)\[.+\]/
+            unless variables_in_scope.include? token.value.gsub(/\[.+\]\Z/, '')
+              unless token.value =~ /\A\d+\Z/
+                notify :warning, {
+                  :message => msg,
+                  :line    => token.line,
+                  :column  => token.column,
+                }
+              end
             end
           end
         end

--- a/spec/puppet-lint/plugins/check_classes/variable_scope_spec.rb
+++ b/spec/puppet-lint/plugins/check_classes/variable_scope_spec.rb
@@ -179,4 +179,18 @@ describe 'variable_scope' do
       end
     end
   end
+
+  context 'support the use of facts and trusted facts for Puppet 3.5 onwards' do
+    let(:code) { "
+      class foo() {
+        if $facts['osfamily'] == 'redhat' or $trusted['osfamily'] == 'redhat' {
+         $redhat = true
+        }
+      }
+    " }
+
+    it 'should not detect any problems' do
+      expect(problems).to have(0).problems
+    end
+  end
 end


### PR DESCRIPTION
For more information on $facts and $trusted see https://docs.puppetlabs.com/puppet/latest/reference/lang_facts_and_builtin_vars.html

Hopefully this meets with your approval, if not please let me know how this can be done and I will revise it :)

Thanks
-Richard
