### PR TITLE
Nested cases

### DIFF
--- a/lib/puppet-lint/plugins/check_conditionals.rb
+++ b/lib/puppet-lint/plugins/check_conditionals.rb
@@ -46,8 +46,12 @@ PuppetLint.new_check(:case_without_default) do
       end
     end
 
-    case_indexes.each do |kase|
+    case_indexes.each_with_index do |kase,kase_index|
       case_tokens = tokens[kase[:start]..kase[:end]]
+
+      case_indexes[(kase_index + 1)..-1].each do |successor_kase|
+	case_tokens -= tokens[successor_kase[:start]..successor_kase[:end]]
+      end
 
       unless case_tokens.index { |r| r.type == :DEFAULT }
         notify :warning, {

--- a/spec/puppet-lint/plugins/check_conditionals/case_without_default_spec.rb
+++ b/spec/puppet-lint/plugins/check_conditionals/case_without_default_spec.rb
@@ -32,6 +32,48 @@ describe 'case_without_default' do
       expect(problems).to contain_warning(msg).on_line(2).in_column(7)
     end
   end
+  
+  context 'nested case statements without a default case on the outermost' do
+    let(:code) { "
+      case $foo {
+        case $foop {
+	  bar: {}
+	  default: {}
+	}
+      }"
+    }
+
+    it 'should only detect a single problem' do
+      expect(problems).to have(1).problem
+    end
+
+    it 'should create a warning' do
+      expect(problems).to contain_warning(msg)
+    end
+  end
+
+  context 'three nested case statements with two missing default cases' do
+    let(:code) { "
+      case $foo {
+        case $foop {
+	  bar: {}
+	  case $woop {
+	    baz: {}
+	  }
+	  default: {}
+	}
+      }"
+    }
+
+    it 'should detect two problems' do
+      expect(problems).to have(2).problems
+    end
+
+    it 'should create two warnings' do
+      expect(problems).to contain_warning(msg).on_line(2).in_column(7)
+      expect(problems).to contain_warning(msg).on_line(5).in_column(4)
+    end
+  end
 
   context 'issue-117' do
     let(:code) { "


### PR DESCRIPTION
Previously, it was possible to miss case statements without a default case when there were nested case statements in the mix. This came up when I was answering this question on ask.puppetlabs.com:

http://ask.puppetlabs.com/question/14669/puppet-rspec-fails-when-testing-against-none-standard-type/

I was planning to suggest running puppet-lint to catch the error, but when I tried it didn't seem to be working - it didn't notice the case statement without a default, because there was another case statement enclosed that did have one.

This commit fixes that problem by ensuring that default cases are matched up with their owning case statement, and not with any other case statements that might exist within the scope.