### PR TITLE
Only clear task if it's already defined

### DIFF
--- a/lib/puppet-lint/tasks/puppet-lint.rb
+++ b/lib/puppet-lint/tasks/puppet-lint.rb
@@ -51,7 +51,7 @@ class PuppetLint
       task_block.call(*[self, args].slice(0, task_block.arity)) if task_block
 
       # clear any (auto-)pre-existing task
-      Rake::Task[@name].clear
+      Rake::Task[@name].clear if Rake::Task.task_defined?(@name)
       task @name do
         PuppetLint::OptParser.build
 


### PR DESCRIPTION
Else rake throws a RuntimeError, "Don't know how to build task 'lint'"

---

Since 0f2e2db / #331 / #332, requiring the file that loads the initial lint rake task throws the following error:

<pre>$ irb -Ilib -rpuppet-lint/tasks/puppet-lint
/home/dcleal/.rvm/gems/ruby-2.0.0-p247@global/gems/rake-10.1.0/lib/rake/task_manager.rb:49:in `[]': Don't know how to build task 'lint' (RuntimeError)
        from /home/dcleal/.rvm/gems/ruby-2.0.0-p247@global/gems/rake-10.1.0/lib/rake/task.rb:348:in `[]'
        from /home/dcleal/code/puppet/puppet-lint/lib/puppet-lint/tasks/puppet-lint.rb:54:in `define'
        from /home/dcleal/code/puppet/puppet-lint/lib/puppet-lint/tasks/puppet-lint.rb:45:in `initialize'
        from /home/dcleal/code/puppet/puppet-lint/lib/puppet-lint/tasks/puppet-lint.rb:87:in `new'
        from /home/dcleal/code/puppet/puppet-lint/lib/puppet-lint/tasks/puppet-lint.rb:87:in `&lt;top (required)&gt;'
        from /home/dcleal/.rvm/rubies/ruby-2.0.0-p247/lib/ruby/site_ruby/2.0.0/rubygems/core_ext/kernel_require.rb:51:in `require'
        from /home/dcleal/.rvm/rubies/ruby-2.0.0-p247/lib/ruby/site_ruby/2.0.0/rubygems/core_ext/kernel_require.rb:51:in `require'
        from /home/dcleal/.rvm/rubies/ruby-2.0.0-p247/lib/ruby/2.0.0/irb/init.rb:286:in `block in load_modules'
        from /home/dcleal/.rvm/rubies/ruby-2.0.0-p247/lib/ruby/2.0.0/irb/init.rb:284:in `each'
        from /home/dcleal/.rvm/rubies/ruby-2.0.0-p247/lib/ruby/2.0.0/irb/init.rb:284:in `load_modules'
        from /home/dcleal/.rvm/rubies/ruby-2.0.0-p247/lib/ruby/2.0.0/irb/init.rb:20:in `setup'
        from /home/dcleal/.rvm/rubies/ruby-2.0.0-p247/lib/ruby/2.0.0/irb.rb:380:in `start'
        from /home/dcleal/.rvm/rubies/ruby-2.0.0-p247/bin/irb:16:in `&lt;main&gt;'
</pre>

It appears it's not checking if the task is defined or not before attempting to clear it.