### PR TITLE
Save the raw value of MLCOMMENT tokens to use when rendering back to a manifest

### DIFF
--- a/lib/puppet-lint/lexer.rb
+++ b/lib/puppet-lint/lexer.rb
@@ -195,10 +195,12 @@ class PuppetLint
 
           elsif mlcomment = chunk[/\A(\/\*.*?\*\/)/m, 1]
             length = mlcomment.size
+            mlcomment_raw = mlcomment.dup
             mlcomment.sub!(/\A\/\* ?/, '')
             mlcomment.sub!(/ ?\*\/\Z/, '')
-            mlcomment.gsub!(/ *\* ?/, '')
+            mlcomment.gsub!(/^ *\*/, '')
             tokens << new_token(:MLCOMMENT, mlcomment, length)
+            tokens.last.raw = mlcomment_raw
 
           elsif chunk.match(/\A\/.*?\//) && possible_regex?
             str_content = StringScanner.new(code[i+1..-1]).scan_until(/(\A|[^\\])(\\\\)*\//m)

--- a/lib/puppet-lint/lexer.rb
+++ b/lib/puppet-lint/lexer.rb
@@ -198,7 +198,6 @@ class PuppetLint
             mlcomment.sub!(/\A\/\* ?/, '')
             mlcomment.sub!(/ ?\*\/\Z/, '')
             mlcomment.gsub!(/ *\* ?/, '')
-            mlcomment.strip!
             tokens << new_token(:MLCOMMENT, mlcomment, length)
 
           elsif chunk.match(/\A\/.*?\//) && possible_regex?

--- a/lib/puppet-lint/lexer/token.rb
+++ b/lib/puppet-lint/lexer/token.rb
@@ -9,6 +9,9 @@ class PuppetLint
       # Public: Returns the String value of the Token.
       attr_accessor :value
 
+      # Public: Returns the raw value of the Token.
+      attr_accessor :raw
+
       # Public: Returns the Integer line number of the manifest text where
       # the Token can be found.
       attr_reader :line
@@ -87,6 +90,8 @@ class PuppetLint
           "##{@value}"
         when :REGEX
           "/#{@value}/"
+        when :MLCOMMENT
+          @raw
         else
           @value
         end

--- a/lib/puppet-lint/plugins/check_comments.rb
+++ b/lib/puppet-lint/plugins/check_comments.rb
@@ -36,7 +36,7 @@ PuppetLint.new_check(:star_comments) do
   end
 
   def fix(problem)
-    comment_lines = problem[:token].value.strip.split("\n")
+    comment_lines = problem[:token].value.strip.split("\n").map(&:strip)
     first_line = comment_lines.shift
     problem[:token].type = :COMMENT
     problem[:token].value = " #{first_line}"

--- a/lib/puppet-lint/plugins/check_comments.rb
+++ b/lib/puppet-lint/plugins/check_comments.rb
@@ -36,7 +36,7 @@ PuppetLint.new_check(:star_comments) do
   end
 
   def fix(problem)
-    comment_lines = problem[:token].value.split("\n")
+    comment_lines = problem[:token].value.strip.split("\n")
     first_line = comment_lines.shift
     problem[:token].type = :COMMENT
     problem[:token].value = " #{first_line}"

--- a/spec/puppet-lint/lexer_spec.rb
+++ b/spec/puppet-lint/lexer_spec.rb
@@ -687,7 +687,7 @@ describe PuppetLint::Lexer do
     it 'should match comments on multiple lines' do
       token = @lexer.tokenise("/* foo\n * bar\n*/").first
       expect(token.type).to eq(:MLCOMMENT)
-      expect(token.value).to eq("foo\nbar\n")
+      expect(token.value).to eq("foo\n bar\n")
     end
   end
 

--- a/spec/puppet-lint/lexer_spec.rb
+++ b/spec/puppet-lint/lexer_spec.rb
@@ -687,7 +687,7 @@ describe PuppetLint::Lexer do
     it 'should match comments on multiple lines' do
       token = @lexer.tokenise("/* foo\n * bar\n*/").first
       expect(token.type).to eq(:MLCOMMENT)
-      expect(token.value).to eq("foo\nbar")
+      expect(token.value).to eq("foo\nbar\n")
     end
   end
 


### PR DESCRIPTION
Spent a bit of time trying to find a sane way of reconstructing `:MLCOMMENT` tokens to fix #373 but it ended up just being a mess of corner cases as it was too easy to break with slight formatting changes.  Decided it was saner to just store the raw value to use when rendering them back into manifest form while retaining the stripped down value to use when converting to `:COMMENT` tokens.

Closes #373