### PR TITLE
Detect trailing whitespace on lines with no code

### DIFF
--- a/lib/puppet-lint/plugins/check_whitespace.rb
+++ b/lib/puppet-lint/plugins/check_whitespace.rb
@@ -26,7 +26,7 @@ end
 PuppetLint.new_check(:trailing_whitespace) do
   def check
     tokens.select { |token|
-      token.type == :WHITESPACE
+      [:WHITESPACE, :INDENT].include?(token.type)
     }.select { |token|
       token.next_token.nil? || token.next_token.type == :NEWLINE
     }.each do |token|

--- a/spec/puppet-lint/plugins/check_whitespace/trailing_whitespace_spec.rb
+++ b/spec/puppet-lint/plugins/check_whitespace/trailing_whitespace_spec.rb
@@ -15,6 +15,22 @@ describe 'trailing_whitespace' do
         expect(problems).to contain_error(msg).on_line(1).in_column(4)
       end
     end
+
+    context 'line without code and trailing whitespace' do
+      let(:code) { "
+class {
+  
+}
+" }
+
+      it 'should only detect a single problem' do
+        expect(problems).to have(1).problem
+      end
+
+      it 'should create an error' do
+        expect(problems).to contain_error(msg).on_line(3).in_column(1)
+      end
+    end
   end
 
   context 'with fix enabled' do
@@ -55,6 +71,30 @@ describe 'trailing_whitespace' do
 
       it 'should remove the trailing whitespace' do
         expect(manifest).to eq("foo\nbar")
+      end
+    end
+
+    context 'line without code and trailing whitespace' do
+      let(:code) { "
+class foo {
+  
+}
+" }
+      let(:fixed) { "
+class foo {
+
+}
+" }
+      it 'should only detect a single problem' do
+        expect(problems).to have(1).problem
+      end
+
+      it 'should create an error' do
+        expect(problems).to contain_fixed(msg).on_line(3).in_column(1)
+      end
+
+      it 'should remove the trailing whitespace' do
+        expect(manifest).to eq(fixed)
       end
     end
   end


### PR DESCRIPTION
Due to how the tokeniser works, whitespace following a `:NEWLINE` token has a token type of `:INDENT` rather than `:WHITESPACE` (for easier logic in some checks). The `trailing_newline` check needs to check for these tokens too.

Closes #359