### PR TITLE
Skip checks on empty files

### DIFF
--- a/lib/puppet-lint.rb
+++ b/lib/puppet-lint.rb
@@ -164,6 +164,12 @@ class PuppetLint
       raise PuppetLint::NoCodeError
     end
 
+    if @code.empty?
+      @problems = []
+      @manifest = []
+      return
+    end
+
     linter = PuppetLint::Checks.new
     @problems = linter.run(@path, @code)
     @problems.each { |problem| @statistics[problem[:kind]] += 1 }


### PR DESCRIPTION
This is an alternate solution to rodjek/puppet-lint#392.

This also fixes dealing with empty files in all plugins. So perhaps this is a better solution.