### PR TITLE
Get ignore_paths from the configuration

### DIFF
--- a/lib/puppet-lint/tasks/puppet-lint.rb
+++ b/lib/puppet-lint/tasks/puppet-lint.rb
@@ -64,6 +64,10 @@ class PuppetLint
           PuppetLint.configuration.send("#{config}=".to_sym, value) unless value.nil?
         end
 
+        if PuppetLint.configuration.ignore_paths
+          @ignore_paths = PuppetLint.configuration.ignore_paths
+        end
+
         RakeFileUtils.send(:verbose, true) do
           linter = PuppetLint.new
           matched_files = FileList[@pattern]


### PR DESCRIPTION
I noticed that ignore_paths is not working when set as documented.
```
PuppetLint.configuration.ignore_paths = ["spec/**/*.pp", "pkg/**/*.pp"]
```

Simply because @ignore_paths is defined on task creation.

There are two examples, the one configuring the tasks works of course,
the second like above doesn't work without my addition.

Make sense?