### PR TITLE
Add in an option to set arbitrary variables as default scope.

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ the PuppetLint configuration by defining the task yourself.
 
       # Compare module layout relative to the module root
       config.relative = true
+
+      # Add in extra variables you've added that are in the default scope
+      config.scope_variables = ['serverenv','serverrole','servertype']
     end
 
 ## Implemented tests

--- a/lib/puppet-lint/configuration.rb
+++ b/lib/puppet-lint/configuration.rb
@@ -148,6 +148,7 @@ class PuppetLint
       self.with_context = false
       self.fix = false
       self.show_ignored = false
+      self.scope_variables = []
     end
   end
 end

--- a/lib/puppet-lint/optparser.rb
+++ b/lib/puppet-lint/optparser.rb
@@ -50,6 +50,10 @@ class PuppetLint::OptParser
         PuppetLint.configuration.show_ignored = true
       end
 
+      opts.on('--scope-variables SCOPES', Array, 'Add extra default scope variables to ignore') do |scopes|
+        PuppetLint.configuration.scope_variables = scopes
+      end
+
       opts.on('--relative', 'Compare module layout relative to the module root') do
         PuppetLint.configuration.relative = true
       end

--- a/lib/puppet-lint/plugins/check_classes.rb
+++ b/lib/puppet-lint/plugins/check_classes.rb
@@ -202,6 +202,7 @@ PuppetLint.new_check(:variable_scope) do
 
   def check
     variables_in_scope = DEFAULT_SCOPE_VARS.clone
+    variables_in_scope.merge(PuppetLint.configuration.scope_variables)
 
     (class_indexes + defined_type_indexes).each do |idx|
       referenced_variables = Set[]

--- a/lib/puppet-lint/tasks/puppet-lint.rb
+++ b/lib/puppet-lint/tasks/puppet-lint.rb
@@ -26,6 +26,7 @@ class PuppetLint
     attr_accessor :with_context
     attr_accessor :fix
     attr_accessor :show_ignored
+    attr_accessor :scope_variables
     attr_accessor :relative
 
     # Public: Initialise a new PuppetLint::RakeTask.
@@ -59,7 +60,7 @@ class PuppetLint
           PuppetLint.configuration.send("disable_#{check}")
         end
 
-        %w{with_filename fail_on_warnings error_level log_format with_context fix show_ignored relative}.each do |config|
+        %w{with_filename fail_on_warnings error_level log_format with_context fix show_ignored scope_variables relative}.each do |config|
           value = instance_variable_get("@#{config}")
           PuppetLint.configuration.send("#{config}=".to_sym, value) unless value.nil?
         end

--- a/spec/puppet-lint/configuration_spec.rb
+++ b/spec/puppet-lint/configuration_spec.rb
@@ -51,6 +51,7 @@ describe PuppetLint::Configuration do
       'with_context' => false,
       'fix' => false,
       'show_ignored' => false,
+      'scope_variables' => [],
     })
   end
 end

--- a/spec/puppet-lint/plugins/check_classes/variable_scope_spec.rb
+++ b/spec/puppet-lint/plugins/check_classes/variable_scope_spec.rb
@@ -103,6 +103,26 @@ describe 'variable_scope' do
     end
   end
 
+  context 'defined type with no variables declared accessing top scope' do
+    before(:all) do
+      PuppetLint.configuration.scope_variables = ['fqdn']
+    end
+
+    after(:all) do
+      PuppetLint.configuration.scope_variables = []
+    end
+
+    let(:code) { "
+      define foo() {
+        $bar = $fqdn
+      }"
+    }
+
+    it 'should not detect any problems' do
+      expect(problems).to have(0).problems
+    end
+  end
+
   context 'defined type with no variables declared accessing top scope explicitly' do
     let(:code) { "
       define foo() {


### PR DESCRIPTION
The use case for this is a bit strange, but if you add some variable in
the default scope (as my company has done), you will trigger several
erroneous lint warnings as those variables don't specify the top-scope
(::serverenv). The check, however, is still valid in several places, and
we don't want to not trigger on that warning when it does detect a
legitimate error.

This changeset will add in an optional parameter to the puppet-lint CLI
and Rake tasks that allow you to specify a list of variables that will
be ignored from this check.

Tests were added and the README was updated in this commit.
