### PR TITLE
Custom fileserver urls/mount points

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ the PuppetLint configuration by defining the task yourself.
       # Show ignored problems in the output, defaults to false
       config.show_ignored = true
 
+      # Add custom fileserver URLs
+      config.file_server_conf = 'modules/puppet/files/fileserver.conf'
+
       # Compare module layout relative to the module root
       config.relative = true
     end

--- a/lib/puppet-lint/configuration.rb
+++ b/lib/puppet-lint/configuration.rb
@@ -146,6 +146,7 @@ class PuppetLint
       self.error_level = :all
       self.log_format = ''
       self.with_context = false
+      self.file_server_conf = false
       self.fix = false
       self.show_ignored = false
     end

--- a/lib/puppet-lint/optparser.rb
+++ b/lib/puppet-lint/optparser.rb
@@ -46,6 +46,10 @@ class PuppetLint::OptParser
         PuppetLint.configuration.error_level = el
       end
 
+      opts.on('--file-server-conf FILE', 'Take a standard fileserver.conf and pull out the puppet:// url strings') do |file|
+        PuppetLint.configuration.file_server_conf = file
+      end
+
       opts.on('--show-ignored', 'Show problems that have been ignored by control comments') do
         PuppetLint.configuration.show_ignored = true
       end

--- a/lib/puppet-lint/plugins/check_strings.rb
+++ b/lib/puppet-lint/plugins/check_strings.rb
@@ -150,14 +150,22 @@ PuppetLint.new_check(:quoted_booleans) do
 end
 
 # Public: Check the manifest tokens for any puppet:// URL strings where the
-# path section doesn't start with modules/ and record a warning for each
-# instance found.
+# path section doesn't start with modules/ or any other configured urls and
+# record a warning for each instance found.
 PuppetLint.new_check(:puppet_url_without_modules) do
   def check
+    if PuppetLint.configuration.file_server_conf
+      fs_lines = File.readlines(PuppetLint.configuration.file_server_conf)
+      # Get the bracketed fileserver name and strip comments
+      url_strings = fs_lines.select { |lines| !lines.match(/#/) && lines.match(/\[(\w+)\]/) }
+      url_strings.map! { |url| url.match(/\[(\w+)\]/); $1 } # Capture the string itself
+    else
+      url_strings = []
+    end
     tokens.select { |token|
       token.type == :SSTRING && token.value.start_with?('puppet://')
     }.reject { |token|
-      token.value[/puppet:\/\/.*?\/(.+)/, 1].start_with?('modules/')
+      token.value[/puppet:\/\/.*?\/(.+)/, 1].start_with?('modules/', *url_strings) # Splat out the array as arguments
     }.each do |token|
       notify :warning, {
         :message => 'puppet:// URL without modules/ found',

--- a/lib/puppet-lint/plugins/check_strings.rb
+++ b/lib/puppet-lint/plugins/check_strings.rb
@@ -159,7 +159,7 @@ PuppetLint.new_check(:puppet_url_without_modules) do
       # Get the bracketed fileserver name and strip comments
       url_strings = fs_lines.select { |lines| !lines.match(/#/) && lines.match(/\[(\w+)\]/) }
       url_strings.map! { |url| url.match(/\[(\w+)\]/); $1 } # Capture the string itself
-      url_msg = " or #{url_strings.join(',')} "
+      url_msg = " or #{url_strings.join(', or ')} "
     else
       url_strings = []
       url_msg = " "

--- a/lib/puppet-lint/plugins/check_strings.rb
+++ b/lib/puppet-lint/plugins/check_strings.rb
@@ -159,8 +159,10 @@ PuppetLint.new_check(:puppet_url_without_modules) do
       # Get the bracketed fileserver name and strip comments
       url_strings = fs_lines.select { |lines| !lines.match(/#/) && lines.match(/\[(\w+)\]/) }
       url_strings.map! { |url| url.match(/\[(\w+)\]/); $1 } # Capture the string itself
+      url_msg = " or #{url_strings.join(',')} "
     else
       url_strings = []
+      url_msg = " "
     end
     tokens.select { |token|
       token.type == :SSTRING && token.value.start_with?('puppet://')
@@ -168,7 +170,7 @@ PuppetLint.new_check(:puppet_url_without_modules) do
       token.value[/puppet:\/\/.*?\/(.+)/, 1].start_with?('modules/', *url_strings) # Splat out the array as arguments
     }.each do |token|
       notify :warning, {
-        :message => 'puppet:// URL without modules/ found',
+        :message => "puppet:// URL without modules/#{url_msg}found",
         :line    => token.line,
         :column  => token.column,
       }

--- a/lib/puppet-lint/tasks/puppet-lint.rb
+++ b/lib/puppet-lint/tasks/puppet-lint.rb
@@ -22,6 +22,7 @@ class PuppetLint
     attr_accessor :disable_checks
     attr_accessor :fail_on_warnings
     attr_accessor :error_level
+    attr_accessor :file_server_conf
     attr_accessor :log_format
     attr_accessor :with_context
     attr_accessor :fix
@@ -59,7 +60,7 @@ class PuppetLint
           PuppetLint.configuration.send("disable_#{check}")
         end
 
-        %w{with_filename fail_on_warnings error_level log_format with_context fix show_ignored relative}.each do |config|
+        %w{with_filename fail_on_warnings error_level log_format with_context file_server_conf fix show_ignored relative}.each do |config|
           value = instance_variable_get("@#{config}")
           PuppetLint.configuration.send("#{config}=".to_sym, value) unless value.nil?
         end

--- a/spec/fixtures/test/manifests/fileserver.conf
+++ b/spec/fixtures/test/manifests/fileserver.conf
@@ -1,0 +1,8 @@
+# Some errant comments to be parsed out
+# [plugins]
+# allow *
+# path /etc/init.d/blerg
+
+[bigfiles]
+  allow *
+  path /data/bigfiles

--- a/spec/puppet-lint/configuration_spec.rb
+++ b/spec/puppet-lint/configuration_spec.rb
@@ -47,6 +47,7 @@ describe PuppetLint::Configuration do
       'with_filename' => false,
       'fail_on_warnings' => false,
       'error_level' => :all,
+      'file_server_conf' => false,
       'log_format' => '',
       'with_context' => false,
       'fix' => false,

--- a/spec/puppet-lint/plugins/check_strings/puppet_url_without_modules_spec.rb
+++ b/spec/puppet-lint/plugins/check_strings/puppet_url_without_modules_spec.rb
@@ -22,4 +22,20 @@ describe 'puppet_url_without_modules' do
       expect(problems).to contain_warning(msg).on_line(1).in_column(1)
     end
   end
+
+  context 'puppet:// url with user defined urls' do
+    before(:all) do
+      PuppetLint.configuration.file_server_conf = 'spec/fixtures/test/manifests/fileserver.conf'
+    end
+
+    after(:all) do
+      PuppetLint.configuration.file_server_conf = nil
+    end
+
+    let(:code) { "'puppet:///bigfiles/foo'" }
+
+    it 'should not detect any problems' do
+      expect(problems).to have(0).problems
+    end
+  end
 end


### PR DESCRIPTION
Add in the ability to specify custom puppet:// fileserver urls.

This option takes in a filepath as a parameter. It does some very naive
stripping of commented strings and matches against lines with the
pattern `/\[(\w+)\]/`, such as `[bigfiles]`. It takes the captured group and
then does the same check that was done for the 'module' string.

This code is a bit hairier than my last PR, and I'm sure it can be done
better. I know there were plans to split this check off into a community
plugin, and I would gladly apply this there if that ever becomes the
case.
