### PR TITLE
Fix puppet:// url check to catch double quoted strings

### DIFF
--- a/lib/puppet-lint/plugins/check_strings.rb
+++ b/lib/puppet-lint/plugins/check_strings.rb
@@ -155,9 +155,9 @@ end
 PuppetLint.new_check(:puppet_url_without_modules) do
   def check
     tokens.select { |token|
-      token.type == :SSTRING && token.value.start_with?('puppet://')
+      (token.type == :SSTRING || token.type == :STRING || token.type == :DQPRE) && token.value.start_with?('puppet://')
     }.reject { |token|
-      token.value[/puppet:\/\/.*?\/(.+)/, 1].start_with?('modules/')
+      token.value[/puppet:\/\/.*?\/(.+)/, 1].start_with?('modules/') unless token.value[/puppet:\/\/.*?\/(.+)/, 1].nil?
     }.each do |token|
       notify :warning, {
         :message => 'puppet:// URL without modules/ found',

--- a/spec/fixtures/test/manifests/url_interpolation.pp
+++ b/spec/fixtures/test/manifests/url_interpolation.pp
@@ -1,0 +1,12 @@
+file { 'test1':
+  source => 'puppet:///foo'
+}
+file { 'test2':
+  source => "puppet:///foo/${::fqdn}"
+}
+file { 'test3':
+  source => "puppet:///${::fqdn}/foo"
+}
+file { 'test4':
+  source => "puppet:///foo/${::fqdn}/bar"
+}

--- a/spec/puppet-lint/plugins/check_strings/puppet_url_without_modules_spec.rb
+++ b/spec/puppet-lint/plugins/check_strings/puppet_url_without_modules_spec.rb
@@ -26,7 +26,7 @@ describe 'puppet_url_without_modules' do
   context 'double string wrapped puppet:// urls' do
     let(:code) { File.read('spec/fixtures/test/manifests/url_interpolation.pp') }
 
-    it 'should only detect a single problem' do
+    it 'should detect several problems' do
       expect(problems).to have(4).problem
     end
 

--- a/spec/puppet-lint/plugins/check_strings/puppet_url_without_modules_spec.rb
+++ b/spec/puppet-lint/plugins/check_strings/puppet_url_without_modules_spec.rb
@@ -23,7 +23,7 @@ describe 'puppet_url_without_modules' do
     end
   end
   
-  context 'string interpolated puppet:// urls' do
+  context 'double string wrapped puppet:// urls' do
     let(:code) { File.read('spec/fixtures/test/manifests/url_interpolation.pp') }
 
     it 'should only detect a single problem' do

--- a/spec/puppet-lint/plugins/check_strings/puppet_url_without_modules_spec.rb
+++ b/spec/puppet-lint/plugins/check_strings/puppet_url_without_modules_spec.rb
@@ -22,4 +22,13 @@ describe 'puppet_url_without_modules' do
       expect(problems).to contain_warning(msg).on_line(1).in_column(1)
     end
   end
+  
+  context 'string interpolated puppet:// urls' do
+    let(:code) { File.read('spec/fixtures/test/manifests/url_interpolation.pp') }
+
+    it 'should only detect a single problem' do
+      expect(problems).to have(4).problem
+    end
+
+  end
 end


### PR DESCRIPTION
Currently, it misses all but 'test1' from the url_interpolation.pp file below. This corrects that.