### PR TITLE
Fix arrow_alignment check to not raise exception when line isn't indented

### DIFF
--- a/lib/puppet-lint/plugins/check_whitespace.rb
+++ b/lib/puppet-lint/plugins/check_whitespace.rb
@@ -112,7 +112,8 @@ PuppetLint.new_check(:arrow_alignment) do
         if token.type == :FARROW
           (level_tokens[indent_depth_idx] ||= []) << token
           prev_indent_token = resource_tokens[0..idx].rindex { |t| t.type == :INDENT }
-          indent_length = resource_tokens[prev_indent_token].to_manifest.length + token.prev_code_token.to_manifest.length + 2
+          indent_token_length = prev_indent_token.nil? ? 0 : resource_tokens[prev_indent_token].to_manifest.length
+          indent_length = indent_token_length + token.prev_code_token.to_manifest.length + 2
 
           if indent_depth[indent_depth_idx] < indent_length
             indent_depth[indent_depth_idx] = indent_length


### PR DESCRIPTION
Closes #409