### PR TITLE
Changed character width to 140.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ the PuppetLint configuration by defining the task yourself.
       config.ignore_paths = ['modules/apt', 'modules/stdlib']
 
       # List of checks to disable
-      config.disable_checks = ['documentation', '80chars']
+      config.disable_checks = ['documentation', '140chars']
 
       # Should puppet-lint prefix it's output with the file being checked,
       # defaults to true
@@ -73,7 +73,7 @@ At the moment, the following tests have been implemented:
  * Must use two-space soft tabs.
  * Must not use literal tab characters.
  * Must not contain trailing white space.
- * Should not exceed an 80 character line width
+ * Should not exceed an 140 character line width
    * An exception has been made for `source => 'puppet://...'` lines as
      splitting these over multiple lines decreases the readability of the
      manifests.
@@ -124,10 +124,10 @@ At the moment, the following tests have been implemented:
 
 You can disable any of the checks when running the `puppet-lint` command by
 adding a `--no-<check name>-check` flag to the command.  For example, if you
-wanted to skip the 80 character check, you would run
+wanted to skip the 140 character check, you would run
 
 ```
-puppet-lint --no-80chars-check /path/to/my/manifest.pp
+puppet-lint --no-140chars-check /path/to/my/manifest.pp
 ```
 
 puppet-lint will also check for a `.puppet-lint.rc` file in the current
@@ -155,10 +155,10 @@ task.  Simply add the following line after the `require` statement in your
 PuppetLint.configuration.send("disable_<check name>")
 ```
 
-So, to disable the 80 character check, you would add:
+So, to disable the 140 character check, you would add:
 
 ``` ruby
-PuppetLint.configuration.send("disable_80chars")
+PuppetLint.configuration.send("disable_140chars")
 ```
 
 The Rake task also supports ignoring certain paths

--- a/lib/puppet-lint/plugins/check_whitespace.rb
+++ b/lib/puppet-lint/plugins/check_whitespace.rb
@@ -48,19 +48,19 @@ PuppetLint.new_check(:trailing_whitespace) do
   end
 end
 
-# Public: Test the raw manifest string for lines containing more than 80
+# Public: Test the raw manifest string for lines containing more than 140
 # characters and record a warning for each instance found.  The only exceptions
 # to this rule are lines containing URLs and template() calls which would hurt
 # readability if split.
-PuppetLint.new_check(:'80chars') do
+PuppetLint.new_check(:'140chars') do
   def check
     manifest_lines.each_with_index do |line, idx|
       unless line =~ /:\/\// || line =~ /template\(/
-        if line.scan(/./mu).size > 80
+        if line.scan(/./mu).size > 140
           notify :warning, {
-            :message => 'line has more than 80 characters',
+            :message => 'line has more than 140 characters',
             :line    => idx + 1,
-            :column  => 80,
+            :column  => 140,
           }
         end
       end

--- a/spec/puppet-lint/plugins/check_whitespace/140chars_spec.rb
+++ b/spec/puppet-lint/plugins/check_whitespace/140chars_spec.rb
@@ -1,10 +1,10 @@
 # encoding: utf-8
 require 'spec_helper'
 
-describe '80chars' do
-  let(:msg) { 'line has more than 80 characters' }
+describe '140chars' do
+  let(:msg) { 'line has more than 140 characters' }
 
-  context 'file resource with a source line > 80c' do
+  context 'file resource with a source line > 140c' do
     let(:code) { "
       file {
         source  => 'puppet:///modules/certificates/etc/ssl/private/wildcard.example.com.crt',
@@ -16,7 +16,7 @@ describe '80chars' do
     end
   end
 
-  context 'file resource with a template line > 80c' do
+  context 'file resource with a template line > 140c' do
     let(:code) { "
       file {
         content => template('mymodule/this/is/a/truely/absurdly/long/path/that/should/make/you/feel/bad'),
@@ -40,15 +40,15 @@ describe '80chars' do
     end
   end
 
-  context '81 character line' do
-    let(:code) { 'a' * 81 }
+  context '141 character line' do
+    let(:code) { 'a' * 141 }
 
     it 'should only detect a single problem' do
       expect(problems).to have(1).problem
     end
 
     it 'should create a warning' do
-      expect(problems).to contain_warning(msg).on_line(1).in_column(80)
+      expect(problems).to contain_warning(msg).on_line(1).in_column(140)
     end
   end
 end


### PR DESCRIPTION
Per the Puppet 3.7+ Style Guide (http://docs.puppetlabs.com/guides/style_guide.html#spacing-indentation-and-whitespace) - Module manifests should not exceed a 140-character line width. I've updated the whitespace plugin, its test, and the readme to reflect this.