### PR TITLE
Adding support for logging to STDOUT as JSON

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source 'https://rubygems.org'
 
 gemspec
+gem 'json'

--- a/lib/puppet-lint.rb
+++ b/lib/puppet-lint.rb
@@ -1,4 +1,5 @@
 require 'set'
+require 'json'
 require 'puppet-lint/version'
 require 'puppet-lint/lexer'
 require 'puppet-lint/configuration'
@@ -105,6 +106,16 @@ class PuppetLint
     end
   end
 
+  # Internal: Get the line of the manifest on which the problem was found
+  #
+  # message - A Hash containing all the information about a problem.
+  #
+  # Returns the problematic line as a string.
+  def get_context(message)
+    line = PuppetLint::Data.manifest_lines[message[:line] - 1]
+    return line.strip
+  end
+
   # Internal: Print out the line of the manifest on which the problem was found
   # as well as a marker pointing to the location on the line.
   #
@@ -114,7 +125,7 @@ class PuppetLint
   def print_context(message)
     return if message[:check] == 'documentation'
     return if message[:kind] == :fixed
-    line = PuppetLint::Data.manifest_lines[message[:line] - 1]
+    line = get_context(message)
     offset = line.index(/\S/) || 1
     puts "\n  #{line.strip}"
     printf "%#{message[:column] + 2 - offset}s\n\n", '^'
@@ -127,6 +138,7 @@ class PuppetLint
   #
   # Returns nothing.
   def report(problems)
+    json = []
     problems.each do |message|
       next if message[:kind] == :ignored && !PuppetLint.configuration.show_ignored
 
@@ -134,10 +146,16 @@ class PuppetLint
       message[:linenumber] = message[:line]
 
       if message[:kind] == :fixed || [message[:kind], :all].include?(configuration.error_level)
-        format_message message
-        print_context(message) if configuration.with_context
+        if configuration.json
+          message['context'] = get_context(message) if configuration.with_context
+          json << message
+        else
+          format_message message
+          print_context(message) if configuration.with_context
+        end
       end
     end
+    puts JSON.pretty_generate(json) if configuration.json
   end
 
   # Public: Determine if PuppetLint found any errors in the manifest.

--- a/lib/puppet-lint/configuration.rb
+++ b/lib/puppet-lint/configuration.rb
@@ -147,6 +147,7 @@ class PuppetLint
       self.log_format = ''
       self.with_context = false
       self.fix = false
+      self.json = false
       self.show_ignored = false
     end
   end

--- a/lib/puppet-lint/optparser.rb
+++ b/lib/puppet-lint/optparser.rb
@@ -89,6 +89,10 @@ class PuppetLint::OptParser
         PuppetLint.configuration.log_format = format
       end
 
+      opts.on('--json', 'Log output as JSON') do
+        PuppetLint.configuration.json = true
+      end
+
       opts.separator ''
       opts.separator '    Checks:'
 

--- a/spec/puppet-lint/bin_spec.rb
+++ b/spec/puppet-lint/bin_spec.rb
@@ -275,6 +275,15 @@ describe PuppetLint::Bin do
     end
   end
 
+   context 'when displaying results as json' do
+    let(:args) { [
+      '--json',
+      'spec/fixtures/test/manifests/warning.pp',
+    ] }
+    its(:exitstatus) { is_expected.to eq(0) }
+    its(:stdout) { is_expected.to match(/\[\n  \{/) }
+   end
+
   context 'when hiding ignored problems' do
     let(:args) { [
       'spec/fixtures/test/manifests/ignore.pp'

--- a/spec/puppet-lint/configuration_spec.rb
+++ b/spec/puppet-lint/configuration_spec.rb
@@ -51,6 +51,7 @@ describe PuppetLint::Configuration do
       'with_context' => false,
       'fix' => false,
       'show_ignored' => false,
+      'json' => false,
     })
   end
 end


### PR DESCRIPTION
Parsing the report requires extensive use of the log format option
or another facility. This allows printing the report as JSON to be
consumed and parsed by other tools.