### PR TITLE
Do not fail on missing files

### DIFF
--- a/lib/puppet-lint/bin.rb
+++ b/lib/puppet-lint/bin.rb
@@ -56,7 +56,12 @@ class PuppetLint::Bin
       path.each do |f|
         l = PuppetLint.new
         l.file = f
-        l.run
+        begin
+          l.run
+        rescue PuppetLint::NoCodeError
+          puts "puppet-lint: #{f} does not exist"
+          next
+        end
         l.print_problems
         if l.errors? or (l.warnings? and PuppetLint.configuration.fail_on_warnings)
           return_val = 1
@@ -69,11 +74,6 @@ class PuppetLint::Bin
         end
       end
       return return_val
-
-    rescue PuppetLint::NoCodeError
-      puts "puppet-lint: no file specified or specified file does not exist"
-      puts "puppet-lint: try 'puppet-lint --help' for more information"
-      return 1
     end
   end
 end


### PR DESCRIPTION
This avoids puppet-lint from failing when it meets, e.g. dead symlinks