### PR TITLE
Parameters ordering was only checked on defined types

### DIFF
--- a/lib/puppet-lint/plugins/check_classes.rb
+++ b/lib/puppet-lint/plugins/check_classes.rb
@@ -89,7 +89,7 @@ end
 # parameters listed before required parameters.
 PuppetLint.new_check(:parameter_order) do
   def check
-    defined_type_indexes.each do |class_idx|
+    (class_indexes + defined_type_indexes).each do |class_idx|
       unless class_idx[:param_tokens].nil?
         paren_stack = []
         class_idx[:param_tokens].each_with_index do |token, i|

--- a/spec/puppet-lint/plugins/check_classes/parameter_order_spec.rb
+++ b/spec/puppet-lint/plugins/check_classes/parameter_order_spec.rb
@@ -3,71 +3,75 @@ require 'spec_helper'
 describe 'parameter_order' do
   let(:msg) { 'optional parameter listed before required parameter' }
 
-  context 'define with attrs in order' do
-    let(:code) { "define foo($bar, $baz='gronk') { }" }
+  ['define', 'class'].each do |type|
+    context "#{type} with attrs in order" do
+      let(:code) { "#{type} foo($bar, $baz='gronk') { }" }
 
-    it 'should not detect any problems' do
-      expect(problems).to have(0).problems
-    end
-  end
-
-  context 'define with parameter that calls a function' do
-    let(:code) { "define foo($bar=extlookup($name)) {}" }
-
-    it 'should not detect any problems' do
-      expect(problems).to have(0).problems
-    end
-  end
-
-  context 'define with attrs out of order' do
-    let(:code) { "define foo($bar='baz', $gronk) { }" }
-
-    it 'should only detect a single problem' do
-      expect(problems).to have(1).problem
+      it 'should not detect any problems' do
+        expect(problems).to have(0).problems
+      end
     end
 
-    it 'should create a warning' do
-      expect(problems).to contain_warning(msg).on_line(1).in_column(24)
-    end
-  end
+    context "#{type} with parameter that calls a function" do
+      let(:code) { "#{type} foo($bar=extlookup($name)) {}" }
 
-  context 'class/define parameter set to another variable' do
-    let(:code) { "
-      define foo($bar, $baz = $name, $gronk=$::fqdn) {
-      }"
-    }
-
-    it 'should not detect any problems' do
-      expect(problems).to have(0).problems
-    end
-  end
-
-  context 'class/define parameter set to another variable with incorrect order' do
-    let(:code) { "
-      define foo($baz = $name, $bar, $gronk=$::fqdn) {
-      }"
-    }
-
-    it 'should only detect a single problem' do
-      expect(problems).to have(1).problem
+      it 'should not detect any problems' do
+        expect(problems).to have(0).problems
+      end
     end
 
-    it 'should create a warning' do
-      expect(problems).to contain_warning(msg).on_line(2).in_column(32)
+    context "#{type} with attrs out of order" do
+      let(:code) { "#{type} foo($bar='baz', $gronk) { }" }
+
+      it 'should only detect a single problem' do
+        expect(problems).to have(1).problem
+      end
+
+      col = (type == "class" ? 23 : 24)
+      it 'should create a warning' do
+        expect(problems).to contain_warning(msg).on_line(1).in_column(col)
+      end
     end
-  end
 
-  context 'issue-101' do
-    let(:code) { "
-      define b (
-        $foo,
-        $bar='',
-        $baz={}
-      ) { }
-    " }
+    context "#{type} parameter set to another variable" do
+      let(:code) { "
+        #{type} foo($bar, $baz = $name, $gronk=$::fqdn) {
+        }"
+      }
 
-    it 'should not detect any problems' do
-      expect(problems).to have(0).problems
+      it 'should not detect any problems' do
+        expect(problems).to have(0).problems
+      end
+    end
+
+    context "#{type} parameter set to another variable with incorrect order" do
+      let(:code) { "
+        #{type} foo($baz = $name, $bar, $gronk=$::fqdn) {
+        }"
+      }
+
+      it 'should only detect a single problem' do
+        expect(problems).to have(1).problem
+      end
+
+      col = (type == "class" ? 33 : 34)
+      it 'should create a warning' do
+        expect(problems).to contain_warning(msg).on_line(2).in_column(col)
+      end
+    end
+
+    context 'issue-101' do
+      let(:code) { "
+        #{type} b (
+          $foo,
+          $bar='',
+          $baz={}
+        ) { }
+      " }
+
+      it 'should not detect any problems' do
+        expect(problems).to have(0).problems
+      end
     end
   end
 end


### PR DESCRIPTION
The current parameter order check only checks for defined types and was not checking class types. I think this somehow got unexpectedly remove with the code cleanup.