### PR TITLE
Sidesteps a crash when running puppet-lint -f and tab calculation ends up with a negative number

### DIFF
--- a/lib/puppet-lint/plugins/check_whitespace.rb
+++ b/lib/puppet-lint/plugins/check_whitespace.rb
@@ -148,6 +148,14 @@ PuppetLint.new_check(:arrow_alignment) do
 
   def fix(problem)
     new_ws_len = (problem[:indent_depth] - (problem[:newline_indent].length + problem[:token].prev_code_token.to_manifest.length + 1))
+    if new_ws_len < 0
+      notify :error, {
+        :message => 'Unable to automatically correct whitespace issue, manual intervention needed',
+        :line    => problem[:line],
+        :column  => problem[:column],
+      }
+      return
+    end
     new_ws = ' ' * new_ws_len
     if problem[:newline]
       index = tokens.index(problem[:token].prev_code_token.prev_token)


### PR DESCRIPTION
Sidesteps a crash when running puppet-lint -f in some situations where the internal calculation of tab-width in lib/puppet-lint/plugins/check_whitespace.rb's fix(problem) ends up with a negative number.

The crash occurs on a line which looks like:

      ensure=>"purged"

In the context of:

    if $removeiceweasel == true {
      package{"removeiceweasel":
        name=>"iceweasel",
        ensure=>"purged"
      }
    }

When the file is of type:

    ASCII text, with CRLF line terminators

Specifically in file pkg/runthebusiness-firefox-1.0.0/manifests/init.pp on commit ff3fc7a of the repo https://github.com/runthebusiness/puppet-firefox.

Changing the line terminators from \r\n to \n does not solve the issue.

It should be noted that this patch does not try to resolve the "why" of this issue, it only admits that it does happen from time and sidesteps it. The interesting thing is that the issue seems to be gone on a second run of puppet-lint -f inferring that the issue could be resolved by running the checking plugins in a different order.