### PR TITLE
Fix issue #450: block-local variables aren't recognized with subscripts

### DIFF
--- a/lib/puppet-lint/plugins/check_classes.rb
+++ b/lib/puppet-lint/plugins/check_classes.rb
@@ -263,7 +263,7 @@ PuppetLint.new_check(:variable_scope) do
       msg = "top-scope variable being used without an explicit namespace"
       referenced_variables.each do |token|
         unless future_parser_scopes[token.line].nil?
-          next if future_parser_scopes[token.line].include?(token.value)
+          next if future_parser_scopes[token.line].include?(token.value.gsub(/\[.+\]\Z/, ''))
         end
 
         unless token.value.include? '::'

--- a/spec/puppet-lint/plugins/check_classes/variable_scope_spec.rb
+++ b/spec/puppet-lint/plugins/check_classes/variable_scope_spec.rb
@@ -148,9 +148,10 @@ describe 'variable_scope' do
     let(:code) { "
       class foo() {
         $foo = [1,2]
-        $foo.each |$a, $b| {
+        $foo.each |$a, $b, $d| {
           $a
           $c
+          $d[1]
         }
         $b
       }
@@ -161,7 +162,7 @@ describe 'variable_scope' do
     end
 
     it 'should create two warnings' do
-      expect(problems).to contain_warning(msg).on_line(8).in_column(9)
+      expect(problems).to contain_warning(msg).on_line(9).in_column(9)
       expect(problems).to contain_warning(msg).on_line(6).in_column(11)
     end
   end

--- a/spec/puppet-lint/plugins/check_classes/variable_scope_spec.rb
+++ b/spec/puppet-lint/plugins/check_classes/variable_scope_spec.rb
@@ -147,22 +147,24 @@ describe 'variable_scope' do
   context 'future parser blocks' do
     let(:code) { "
       class foo() {
-        $foo = [1,2]
-        $foo.each |$a, $b, $d| {
-          $a
-          $c
-          $d[1]
+        $foo = {1=>2, 3=>4}
+        $foo.each |$a, $b| {
+          $a    # should cause no warnings
+          $c    # top-scope variable warning
         }
-        $b
+        $b      # top-scope variable warning
+        $foo.each |$d| {
+          $d[1] # should cause no warnings
+        }
       }
     " }
 
-    it 'should only detect a single problem' do
+    it 'should only detect two problems' do
       expect(problems).to have(2).problem
     end
 
     it 'should create two warnings' do
-      expect(problems).to contain_warning(msg).on_line(9).in_column(9)
+      expect(problems).to contain_warning(msg).on_line(8).in_column(9)
       expect(problems).to contain_warning(msg).on_line(6).in_column(11)
     end
   end


### PR DESCRIPTION
Strip subscripts from variable names when checking for future parser
scoped variables.

Update future scope spec test to ensure subscripted references pass.