### PR TITLE
Fix double arrow issue when adding target to ensure symlink

### DIFF
--- a/lib/puppet-lint/plugins/check_resources.rb
+++ b/lib/puppet-lint/plugins/check_resources.rb
@@ -184,7 +184,7 @@ PuppetLint.new_check(:ensure_not_symlink_target) do
       PuppetLint::Lexer::Token.new(:NEWLINE, "\n", 0, 0),
       PuppetLint::Lexer::Token.new(:INDENT, problem[:param_token].prev_token.value.dup, 0, 0),
       PuppetLint::Lexer::Token.new(:NAME, 'target', 0, 0),
-      PuppetLint::Lexer::Token.new(:WHITESPACE, problem[:param_token].next_token.value.dup, 0, 0),
+      PuppetLint::Lexer::Token.new(:WHITESPACE, ' ', 0, 0),
       PuppetLint::Lexer::Token.new(:FARROW, '=>', 0, 0),
       PuppetLint::Lexer::Token.new(:WHITESPACE, ' ', 0, 0),
     ].reverse.each do |new_token|


### PR DESCRIPTION
Fix for issue #341

I tested with:
```
class double_arrow {
    file {'/etc/foo': ensure=>'/usr/share/foo' }
}

class double_arrow_other {
    file {'/etc/foo': ensure =>'/usr/share/foo' }
}

class double_arrow_correct{
    file {'/etc/foo':
        ensure=>'/usr/share/foo'
    }
}
```

Gets turned into:
```
class double_arrow {
    file {'/etc/foo': ensure =>symlink,
 target => '/usr/share/foo' }
}

class double_arrow_other {
    file {'/etc/foo': ensure =>symlink,
 target => '/usr/share/foo' }
}

class double_arrow_correct{
    file {'/etc/foo':
        ensure =>symlink,
        target => '/usr/share/foo'
    }
}
```
Spacing is still off a bit.  however the => => is gone.