### PR TITLE
Support automatic fixing in Rake task as described in README

### DIFF
--- a/lib/puppet-lint/tasks/puppet-lint.rb
+++ b/lib/puppet-lint/tasks/puppet-lint.rb
@@ -79,7 +79,7 @@ class PuppetLint
             linter.run
             linter.print_problems
 
-            if PuppetLint.configuration.fix && !linter.problems.empty?
+            if PuppetLint.configuration.fix && !linter.problems.any? { |e| e[:check] == :syntax }
               IO.write(puppet_file, linter.manifest)
             end
           end

--- a/lib/puppet-lint/tasks/puppet-lint.rb
+++ b/lib/puppet-lint/tasks/puppet-lint.rb
@@ -78,6 +78,10 @@ class PuppetLint
             linter.file = puppet_file
             linter.run
             linter.print_problems
+
+            if PuppetLint.configuration.fix && !linter.problems.empty?
+              IO.write(puppet_file, linter.manifest)
+            end
           end
           abort if linter.errors? || (
             linter.warnings? && PuppetLint.configuration.fail_on_warnings


### PR DESCRIPTION
README says you can configure a Rake task as
```rb
PuppetLint::RakeTask.new :lint do |config|
  # Enable automatic fixing of problems, defaults to false
  config.fix = true
end
```
to enable automatic fixing, but this actually doesn't work now, since writing back fixed manifests is implemented in `lib/puppet-lint/bin.rb` and this code is not called when puppet-lint is invoked as a rake task.

This patch is to fix this problem by making the Rake task write back the fixed manifest to the source file when any problem is found.
