### PR TITLE
Allow regex params for puppet data types

### DIFF
--- a/lib/puppet-lint/lexer.rb
+++ b/lib/puppet-lint/lexer.rb
@@ -62,6 +62,7 @@ class PuppetLint
       :MATCH   => true,
       :NOMATCH => true,
       :COMMA   => true,
+      :LBRACK  => true,
     }
 
     # Internal: An Array of Arrays containing tokens that can be described by

--- a/spec/puppet-lint/lexer_spec.rb
+++ b/spec/puppet-lint/lexer_spec.rb
@@ -767,6 +767,12 @@ describe PuppetLint::Lexer do
       expect(token.value).to eq('this is \\/ a regex')
     end
 
+    it 'should be allowed as a param to a data type' do
+      tokens = @lexer.tokenise('Foo[/bar/]')
+      expect(tokens[2].type).to eq(:REGEX)
+      expect(tokens[2].value).to eq('bar')
+    end
+
     it 'should not match chained division' do
       tokens = @lexer.tokenise('$x = $a/$b/$c')
       expect(tokens.select { |r| r.type == :REGEX }).to be_empty

--- a/spec/puppet-lint/lexer_spec.rb
+++ b/spec/puppet-lint/lexer_spec.rb
@@ -773,6 +773,12 @@ describe PuppetLint::Lexer do
       expect(tokens[2].value).to eq('bar')
     end
 
+    it 'should be allowed as a param to an optional data type' do
+      tokens = @lexer.tokenise('Optional[Regexp[/^puppet/]]')
+      expect(tokens[4].type).to eq(:REGEX)
+      expect(tokens[4].value).to eq('^puppet')
+    end
+
     it 'should not match chained division' do
       tokens = @lexer.tokenise('$x = $a/$b/$c')
       expect(tokens.select { |r| r.type == :REGEX }).to be_empty


### PR DESCRIPTION
fixes #452

Puppet 4 data types such as Parameters and Regexp allow one to use
regexp as a parameter.