### PR TITLE
Fix handling of empty code

### DIFF
--- a/lib/puppet-lint.rb
+++ b/lib/puppet-lint.rb
@@ -166,7 +166,7 @@ class PuppetLint
 
     if @code.empty?
       @problems = []
-      @manifest = []
+      @manifest = ''
       return
     end
 

--- a/spec/puppet-lint_spec.rb
+++ b/spec/puppet-lint_spec.rb
@@ -17,4 +17,10 @@ describe PuppetLint do
     string = 'replace %s %s' % ['get','replaced']
     expect(string).to match('replace get replaced')
   end
+
+  it 'should return empty manifest when empty one given as the input' do
+    subject.code = ''
+    subject.run
+    expect(subject.manifest).to eq ''
+  end
 end


### PR DESCRIPTION
When you pass an empty file (of zero bytes) to the `puppet-lint --fix` command,
puppet-lint generates a strange file with its content being `[]`, which cannot be parsed by Puppet.

This patch fixes this problem.