### PR TITLE
Regression from 418: duplicate constant

### DIFF
--- a/lib/puppet-lint/plugins/check_variables.rb
+++ b/lib/puppet-lint/plugins/check_variables.rb
@@ -1,11 +1,11 @@
 # Public: Test the manifest tokens for variables that contain a dash and
 # record a warning for each instance found.
 PuppetLint.new_check(:variable_contains_dash) do
-  VARIABLE_TYPES = Set[:VARIABLE, :UNENC_VARIABLE]
+  VARIABLE_DASH_TYPES = Set[:VARIABLE, :UNENC_VARIABLE]
 
   def check
     tokens.select { |r|
-      VARIABLE_TYPES.include? r.type
+      VARIABLE_DASH_TYPES.include? r.type
     }.each do |token|
       if token.value.gsub(/\[.+?\]/, '').match(/-/)
         notify :warning, {
@@ -19,11 +19,11 @@ PuppetLint.new_check(:variable_contains_dash) do
 end
 
 PuppetLint.new_check(:variable_is_lowercase) do
-  VARIABLE_TYPES = Set[:VARIABLE, :UNENC_VARIABLE]
+  VARIABLE_LOWERCASE_TYPES = Set[:VARIABLE, :UNENC_VARIABLE]
 
   def check
     tokens.select { |r|
-      VARIABLE_TYPES.include? r.type
+      VARIABLE_LOWERCASE_TYPES.include? r.type
     }.each do |token|
       if token.value.gsub(/\[.+?\]/, '').match(/[A-Z]/)
         notify :warning, {


### PR DESCRIPTION
After merging #418, these warnings started appearing:
```
$ bundle exec puppet-lint --version
/home/rnelson0/git/puppet-lint/lib/puppet-lint/plugins/check_variables.rb:22: warning: already initialized constant VARIABLE_TYPES
/home/rnelson0/git/puppet-lint/lib/puppet-lint/plugins/check_variables.rb:4: warning: previous definition of VARIABLE_TYPES was here
puppet-lint 2.0.0
```
The new token constants for each check had the same name, and have now been given unique names.