### PR TITLE
Silently ignore deprecated --no-80chars-check parameter

### DIFF
--- a/lib/puppet-lint/plugins/check_whitespace.rb
+++ b/lib/puppet-lint/plugins/check_whitespace.rb
@@ -68,6 +68,12 @@ PuppetLint.new_check(:'140chars') do
   end
 end
 
+# Public: Silently ignore deprecated --no-80chars-check parameter
+PuppetLint.new_check(:'80chars') do
+  def check
+  end
+end
+
 # Public: Check the manifest tokens for any indentation not using 2 space soft
 # tabs and record an error for each instance found.
 PuppetLint.new_check(:'2sp_soft_tabs') do


### PR DESCRIPTION
We've found that our CI system automatically uses the latest version of puppet-lint, and spectacularly fails due to a (correctly) removed/changed test.

This fixes that issue for systems that automatically update but can't be updated themselves easily.