### PR TITLE
(GH410) Limit ensure_first_param check to certain resources

### DIFF
--- a/lib/puppet-lint/plugins/check_resources.rb
+++ b/lib/puppet-lint/plugins/check_resources.rb
@@ -25,6 +25,7 @@ end
 PuppetLint.new_check(:ensure_first_param) do
   def check
     resource_indexes.each do |resource|
+      next if [:CLASS].include? resource[:type].type
       ensure_attr_index = resource[:param_tokens].index { |param_token|
         param_token.value == 'ensure'
       }

--- a/spec/puppet-lint/plugins/check_resources/ensure_first_param_spec.rb
+++ b/spec/puppet-lint/plugins/check_resources/ensure_first_param_spec.rb
@@ -52,4 +52,23 @@ describe 'ensure_first_param' do
       expect(problems).to have(0).problems
     end
   end
+
+  context 'ensure as a hash key in classes does not need to be first' do
+    let(:code) { "
+      class thing {
+          class {'thang':
+              stuff => {
+                  'stuffing' => {
+                      ensure => 'present',
+                      blah   => 'bleah',
+                  }
+              },
+          }
+      }"
+    }
+
+    it 'should not detect any problems' do
+      expect(problems).to have(0).problems
+    end
+  end
 end


### PR DESCRIPTION
  "ensure" should be the first attribute for resources that contain that attribute (Guide 9.3). In other resource types, it is a hash key and can come in any order.