### PR TITLE
Fixed failing tests and cleaned up indentation

### DIFF
--- a/lib/puppet-lint/bin.rb
+++ b/lib/puppet-lint/bin.rb
@@ -56,7 +56,12 @@ class PuppetLint::Bin
       path.each do |f|
         l = PuppetLint.new
         l.file = f
-        l.run
+        begin
+          l.run
+        rescue PuppetLint::NoCodeError
+          puts "puppet-lint: #{f} does not exist"
+          next
+        end
         l.print_problems
         if l.errors? or (l.warnings? and PuppetLint.configuration.fail_on_warnings)
           return_val = 1
@@ -69,11 +74,6 @@ class PuppetLint::Bin
         end
       end
       return return_val
-
-    rescue PuppetLint::NoCodeError
-      puts "puppet-lint: no file specified or specified file does not exist"
-      puts "puppet-lint: try 'puppet-lint --help' for more information"
-      return 1
     end
   end
 end

--- a/lib/puppet-lint/bin.rb
+++ b/lib/puppet-lint/bin.rb
@@ -40,40 +40,39 @@ class PuppetLint::Bin
       return 1
     end
 
-    begin
-      path = @args[0]
-      if File.directory?(path)
-        path = Dir.glob("#{path}/**/*.pp")
-      else
-        path = @args
-      end
-
-      if path.length > 1
-        PuppetLint.configuration.with_filename = true
-      end
-
-      return_val = 0
-      path.each do |f|
-        l = PuppetLint.new
-        l.file = f
-        begin
-          l.run
-        rescue PuppetLint::NoCodeError
-          puts "puppet-lint: #{f} does not exist"
-          next
-        end
-        l.print_problems
-        if l.errors? or (l.warnings? and PuppetLint.configuration.fail_on_warnings)
-          return_val = 1
-        end
-
-        if PuppetLint.configuration.fix && !l.problems.any? { |e| e[:check] == :syntax }
-          File.open(f, 'w') do |fd|
-            fd.write l.manifest
-          end
-        end
-      end
-      return return_val
+    path = @args[0]
+    if File.directory?(path)
+      path = Dir.glob("#{path}/**/*.pp")
+    else
+      path = @args
     end
+
+    if path.length > 1
+      PuppetLint.configuration.with_filename = true
+    end
+
+    return_val = 0
+    path.each do |f|
+      l = PuppetLint.new
+      l.file = f
+      begin
+        l.run
+      rescue PuppetLint::NoCodeError
+        puts "puppet-lint: #{f} does not exist"
+        next
+      end
+      l.print_problems
+      if l.errors? or (l.warnings? and PuppetLint.configuration.fail_on_warnings)
+        return_val = 1
+      end
+
+      if PuppetLint.configuration.fix && !l.problems.any? { |e| e[:check] == :syntax }
+        File.open(f, 'w') do |fd|
+          fd.write l.manifest
+        end
+      end
+    end
+
+    return return_val
   end
 end

--- a/spec/puppet-lint/bin_spec.rb
+++ b/spec/puppet-lint/bin_spec.rb
@@ -159,8 +159,8 @@ describe PuppetLint::Bin do
   context 'when passed a file that does not exist' do
     let(:args) { 'spec/fixtures/test/manifests/enoent.pp' }
 
-    its(:exitstatus) { is_expected.to eq(1) }
-    its(:stdout) { is_expected.to match(/specified file does not exist/) }
+    its(:exitstatus) { is_expected.to eq(0) }
+    its(:stdout) { is_expected.to match(/does not exist/) }
   end
 
   context 'when passed a directory' do


### PR DESCRIPTION
This will print warnings instead of outright failing on missing files.
This can avoid cases in which a bad symlink inside a directory causes
spurious failures.

For the record, I'm not sure this is a good change.

Supercedes #426