### PR TITLE
(GH416) Wrong arrow alignment when key has interpolated variable

### DIFF
--- a/lib/puppet-lint/lexer.rb
+++ b/lib/puppet-lint/lexer.rb
@@ -364,7 +364,7 @@ class PuppetLint
             lexer.tokens.each do |token|
               tok_col = column + token.column + (ss.pos - contents.size - 1)
               tok_line = token.line + line - 1
-              tokens << new_token(token.type, token.value, token.value.size, :line => tok_line, :column => tok_col)
+              tokens << new_token(token.type, token.value, token.value.size + 3, :line => tok_line, :column => tok_col)
             end
           end
         end

--- a/spec/puppet-lint/plugins/check_whitespace/arrow_alignment_spec.rb
+++ b/spec/puppet-lint/plugins/check_whitespace/arrow_alignment_spec.rb
@@ -570,5 +570,73 @@ describe 'arrow_alignment' do
         expect(manifest).to eq(fixed)
       end
     end
+
+    context 'nested hashes with correct indentation and interpolated variable' do
+      let(:code) { "
+        class example (
+          $external_ip_base,
+        ) {
+        
+          bar { 'xxxxxxxxxxx':
+            inputs => {
+              'ny' => {
+                \"${external_ip_base}.16:443\"  => 'foo',
+                'veryveryverylongstring8:443' => 'foo',
+              },
+            },
+          }
+        }"
+      }
+
+      it 'should not detect any problems' do
+        expect(problems).to have(0).problems
+      end
+    end
+
+    context 'nested hashes with incorrect indentation and interpolated variable' do
+      let(:code) { "
+        class example (
+          $external_ip_base,
+        ) {
+        
+          bar { 'xxxxxxxxxxx':
+            inputs => {
+              'ny' => {
+                \"${external_ip_base}.16:443\"   => 'foo',
+                'veryveryverylongstring8:443' => 'foo',
+              },
+            },
+          }
+        }"
+      }
+
+      let(:fixed) { "
+        class example (
+          $external_ip_base,
+        ) {
+        
+          bar { 'xxxxxxxxxxx':
+            inputs => {
+              'ny' => {
+                \"${external_ip_base}.16:443\"  => 'foo',
+                'veryveryverylongstring8:443' => 'foo',
+              },
+            },
+          }
+        }"
+      }
+
+      it 'should detect 1 problems' do
+        expect(problems).to have(1).problems
+      end
+
+      #it 'should fix the problem' do
+        #expect(problems).to contain_fixed(msg).in_column(48)
+      #end
+
+      #it 'should add whitespace between the param and the arrow' do
+        #expect(manifest).to eq(fixed)
+      #end
+    end
   end
 end


### PR DESCRIPTION
  Ensure that interpolated variable delimiters (`${}`) are not ignored when calculating alignment.
  The `--fix` function remains broken, see #424 for progress on that front.