### PR TITLE
Make params disabled

### DIFF
--- a/lib/puppet-lint/plugins/check_classes.rb
+++ b/lib/puppet-lint/plugins/check_classes.rb
@@ -83,6 +83,7 @@ PuppetLint.new_check(:class_inherits_from_params_class) do
     end
   end
 end
+PuppetLint.configuration.send('disable_class_inherits_from_params_class')
 
 # Public: Test the manifest tokens for any parameterised classes or defined
 # types that take parameters and record a warning if there are any optional

--- a/lib/puppet-lint/plugins/check_classes.rb
+++ b/lib/puppet-lint/plugins/check_classes.rb
@@ -66,6 +66,24 @@ PuppetLint.new_check(:names_containing_dash) do
   end
 end
 
+# Public: Check the manifest tokens for any classes that inherit a params
+# subclass and record a warning for each instance found.
+PuppetLint.new_check(:class_inherits_from_params_class) do
+  def check
+    class_indexes.each do |class_idx|
+      unless class_idx[:inherited_token].nil?
+        if class_idx[:inherited_token].value.end_with? '::params'
+          notify :warning, {
+            :message => 'class inheriting from params class',
+            :line    => class_idx[:inherited_token].line,
+            :column  => class_idx[:inherited_token].column,
+          }
+        end
+      end
+    end
+  end
+end
+
 # Public: Test the manifest tokens for any parameterised classes or defined
 # types that take parameters and record a warning if there are any optional
 # parameters listed before required parameters.

--- a/spec/puppet-lint/plugins/check_classes/class_inherits_from_params_class_spec.rb
+++ b/spec/puppet-lint/plugins/check_classes/class_inherits_from_params_class_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+describe 'class_inherits_from_params_class' do
+  let(:msg) { 'class inheriting from params class' }
+
+  context 'parameterised class that inherits from a params class' do
+    let(:code) { "
+      # commented
+      class foo($bar = $name) inherits foo::params { }"
+    }
+
+    it 'should only detect a single problem' do
+      expect(problems).to have(1).problem
+    end
+
+    it 'should create a warning' do
+      expect(problems).to contain_warning(msg).on_line(3).in_column(40)
+    end
+  end
+
+  context 'class without parameters' do
+    let(:code) {"
+      class myclass {
+
+        if ( $::lsbdistcodename == 'squeeze' ) {
+          #TODO
+        }
+      }
+    "}
+
+    it 'should not detect any problems' do
+      expect(problems).to have(0).problems
+    end
+  end
+end


### PR DESCRIPTION
This reinstates the check removed in #510, but disables it. This will make it less likely that existing tooling will break on this change.

When #495 is merged, it can be re-enabled on invocation.