### PR TITLE
(GH366) Arrow Alignment fix crashes with tabs

### DIFF
--- a/lib/puppet-lint/checks.rb
+++ b/lib/puppet-lint/checks.rb
@@ -58,14 +58,10 @@ class PuppetLint::Checks
       problems = klass.run
 
       if PuppetLint.configuration.fix
-        checks_run << klass
+        @problems.concat(klass.fix_problems)
       else
         @problems.concat(problems)
       end
-    end
-
-    checks_run.each do |check|
-      @problems.concat(check.fix_problems)
     end
 
     @problems


### PR DESCRIPTION
  In #366, an issue was identified where tab indents may cause a negative argument error when creating the new indent for alignment. This occurred because the problem was logged prior to the tab being replaced with two spaces, which changed the alignment.
  The fix is to, when `--fix` is passed, run each plugin's  immediately after it's  method. This ensures that problems are fixed immediately, so the next check runs against the updated code.

This may resolve some of the other issues with `--fix` as well.