### PR TITLE
New additions of protected variables

### DIFF
--- a/lib/puppet-lint/plugins/check_classes.rb
+++ b/lib/puppet-lint/plugins/check_classes.rb
@@ -198,6 +198,9 @@ PuppetLint.new_check(:variable_scope) do
     'stage',
     'subscribe',
     'tag',
+    'fact',
+    'trusted',
+    'server_facts',
   ]
   POST_VAR_TOKENS = Set[:COMMA, :EQUALS, :RPAREN]
 

--- a/lib/puppet-lint/plugins/check_classes.rb
+++ b/lib/puppet-lint/plugins/check_classes.rb
@@ -198,7 +198,7 @@ PuppetLint.new_check(:variable_scope) do
     'stage',
     'subscribe',
     'tag',
-    'fact',
+    'facts',
     'trusted',
     'server_facts',
   ]


### PR DESCRIPTION
Per https://tickets.puppetlabs.com/browse/DOCUMENT-560, these variables are protected and always top level and thus do not need the colons.