### PR TITLE
Remove formatting with `linenumber`

### DIFF
--- a/lib/puppet-lint.rb
+++ b/lib/puppet-lint.rb
@@ -131,7 +131,6 @@ class PuppetLint
       next if message[:kind] == :ignored && !PuppetLint.configuration.show_ignored
 
       message[:KIND] = message[:kind].to_s.upcase
-      message[:linenumber] = message[:line]
 
       if message[:kind] == :fixed || [message[:kind], :all].include?(configuration.error_level)
         format_message message

--- a/lib/puppet-lint/optparser.rb
+++ b/lib/puppet-lint/optparser.rb
@@ -83,9 +83,6 @@ class PuppetLint::OptParser
               '%{check}    - The name of the check.',
               '%{message}  - The message.'
       ) do |format|
-        if format.include?('%{linenumber}')
-          $stderr.puts "DEPRECATION: Please use %{line} instead of %{linenumber}"
-        end
         PuppetLint.configuration.log_format = format
       end
 

--- a/spec/puppet-lint/bin_spec.rb
+++ b/spec/puppet-lint/bin_spec.rb
@@ -213,17 +213,6 @@ describe PuppetLint::Bin do
       }
     end
 
-    context 'to print %{linenumber}' do
-      let(:args) { [
-        '--log-format', '%{linenumber}',
-        'spec/fixtures/test/manifests/fail.pp'
-      ] }
-
-      its(:exitstatus) { is_expected.to eq(1) }
-      its(:stdout) { is_expected.to eq('2') }
-      its(:stderr) { is_expected.to eq('DEPRECATION: Please use %{line} instead of %{linenumber}') }
-    end
-
     context 'to print %{line}' do
       let(:args) { [
         '--log-format', '%{line}',


### PR DESCRIPTION
`linenumber` has been deprecated since v1.0.0, which was released in
Aug 2014. It is time to remove it.

Fixes GH-539

Signed-off-by: Romanos Skiadas <rom.skiad@gmail.com>