### PR TITLE
@node_indexes should be reset too.

### DIFF
--- a/lib/puppet-lint/data.rb
+++ b/lib/puppet-lint/data.rb
@@ -25,6 +25,7 @@ class PuppetLint::Data
       @resource_indexes = nil
       @class_indexes = nil
       @defined_type_indexes = nil
+      @node_indexes = nil
       @function_indexes = nil
       @array_indexes = nil
       @hash_indexes = nil


### PR DESCRIPTION
If a new set of tokens is assigned to a PuppetLint::Data instance the @node_indexes cache should be flushed too, alike @class_indexes or @defined_type_indexes.