### PR TITLE
Multi line strings

### DIFF
--- a/lib/puppet-lint/data.rb
+++ b/lib/puppet-lint/data.rb
@@ -25,6 +25,7 @@ class PuppetLint::Data
       @resource_indexes = nil
       @class_indexes = nil
       @defined_type_indexes = nil
+      @node_indexes = nil
       @function_indexes = nil
       @array_indexes = nil
       @hash_indexes = nil

--- a/lib/puppet-lint/lexer.rb
+++ b/lib/puppet-lint/lexer.rb
@@ -311,6 +311,11 @@ class PuppetLint
         @line_no += 1
         @column = 1
       end
+      if type == :SSTRING and /(?:\r\n|\r|\n)/.match(value)
+        lines = value.split(/(?:\r\n|\r|\n)/)
+        @line_no += lines.length-1
+        @column = lines.last.length
+      end
 
       token
     end

--- a/spec/puppet-lint/lexer_spec.rb
+++ b/spec/puppet-lint/lexer_spec.rb
@@ -18,7 +18,7 @@ describe PuppetLint::Lexer do
     end
 
     it 'should calculate the line number for a multi line string' do
-      @lexer.instance_variable_set('@line_no', 2)
+      token = @lexer.new_token(:SSTRING, "test\ntest", 4)
       token = @lexer.new_token(:TEST, 'test', 4)
       expect(token.line).to eq(2)
     end
@@ -37,8 +37,9 @@ describe PuppetLint::Lexer do
     it 'should calculate the column number for a multi line string' do
       @lexer.instance_variable_set('@line_no', 4)
       @lexer.instance_variable_set('@column', "gronk".size)
+      token = @lexer.new_token(:SSTRING, "test\ntest", 9)
       token = @lexer.new_token(:TEST, 'test', 4)
-      expect(token.column).to eq(5)
+      expect(token.column).to eq(4)
     end
   end
 

--- a/spec/puppet-lint/lexer_spec.rb
+++ b/spec/puppet-lint/lexer_spec.rb
@@ -18,7 +18,7 @@ describe PuppetLint::Lexer do
     end
 
     it 'should calculate the line number for a multi line string' do
-      token = @lexer.new_token(:SSTRING, "test\ntest", 4)
+      token = @lexer.new_token(:SSTRING, "test\ntest", 9)
       token = @lexer.new_token(:TEST, 'test', 4)
       expect(token.line).to eq(2)
     end


### PR DESCRIPTION
The puppet line lexer did not count the newlines in strings. Therefore the tokens have have wrong line number in it. The resulting token read alike this.

```ruby
<Token :SSTRING (test
test) @57:14>
<Token :COMMA (,) @57:24>
```

The error probably was introduced in af3bf4efe71e0b41ffeffa02f1d6185605ba98e8

Even the spec was tweaked to succeed. https://github.com/rodjek/puppet-lint/commit/af3bf4efe71e0b41ffeffa02f1d6185605ba98e8#diff-b9067ea740718189d4de3474b711dba5R21
