### PR TITLE
Anchor the end of the :TYPE token regexp

### DIFF
--- a/lib/puppet-lint/lexer.rb
+++ b/lib/puppet-lint/lexer.rb
@@ -88,7 +88,7 @@ class PuppetLint
     # name of the token as a Symbol and a regular expression describing the
     # value of the token.
     KNOWN_TOKENS = [
-      [:TYPE, /\A(Integer|Float|Boolean|Regexp|String|Array|Hash|Resource|Class|Collection|Scalar|Numeric|CatalogEntry|Data|Tuple|Struct|Optional|NotUndef|Variant|Enum|Pattern|Any|Callable|Type|Runtime|Undef|Default)/],
+      [:TYPE, /\A(Integer|Float|Boolean|Regexp|String|Array|Hash|Resource|Class|Collection|Scalar|Numeric|CatalogEntry|Data|Tuple|Struct|Optional|NotUndef|Variant|Enum|Pattern|Any|Callable|Type|Runtime|Undef|Default)\b/],
       [:CLASSREF, /\A(((::){0,1}[A-Z][-\w]*)+)/],
       [:NUMBER, /\A\b((?:0[xX][0-9A-Fa-f]+|0?\d+(?:\.\d+)?(?:[eE]-?\d+)?))\b/],
       [:NAME, /\A(((::)?[a-z0-9][-\w]*)(::[a-z0-9][-\w]*)*)/],

--- a/spec/puppet-lint/lexer_spec.rb
+++ b/spec/puppet-lint/lexer_spec.rb
@@ -629,6 +629,12 @@ describe PuppetLint::Lexer do
       expect(token.type).to eq(:CLASSREF)
       expect(token.value).to eq('::One')
     end
+
+    it 'should match terms that start with Types' do
+      token = @lexer.tokenise('Regexp_foo').first
+      expect(token.type).to eq(:CLASSREF)
+      expect(token.value).to eq('Regexp_foo')
+    end
   end
 
   context ':NAME' do


### PR DESCRIPTION
Updates the regexp for the `:TYPE` token so that it is anchored at the end with a word boundary, allowing it to match `Regexp` but not `Regexp_foo` for example.

Fixes #566