### PR TITLE
Reimplementation of --fix support for unenclosed variables delimited by dashes

### DIFF
--- a/lib/puppet-lint/lexer.rb
+++ b/lib/puppet-lint/lexer.rb
@@ -188,7 +188,7 @@ class PuppetLint
         end
 
         unless found
-          if var_name = chunk[/\A\$((::)?([\w-]+::)*[\w-]+(\[.+?\])*)/, 1]
+          if var_name = chunk[/\A\$((::)?(\w+(-\w+)*::)*\w+(-\w+)*(\[.+?\])*)/, 1]
             length = var_name.size + 1
             tokens << new_token(:VARIABLE, var_name, length)
 
@@ -364,7 +364,7 @@ class PuppetLint
             tokens << new_token(:DQMID, value, value.size, :line => line, :column => token_column)
           end
           if ss.scan(/\{/).nil?
-            var_name = ss.scan(/(::)?([\w-]+::)*[\w-]+/)
+            var_name = ss.scan(/(::)?(\w+(-\w+)*::)*\w+(-\w+)*/)
             if var_name.nil?
               token_column = column + ss.pos - 1
               tokens << new_token(:DQMID, "$", 1, :line => line, :column => token_column)

--- a/spec/puppet-lint/plugins/check_strings/variables_not_enclosed_spec.rb
+++ b/spec/puppet-lint/plugins/check_strings/variables_not_enclosed_spec.rb
@@ -69,5 +69,22 @@ describe 'variables_not_enclosed' do
         expect(manifest).to eq(("'groovy'\n" * 20) + '" ${gronk}"')
       end
     end
+
+    context 'variables not enclosed in {}, delimited by -' do
+      let(:code) { '"$foo-$bar"' }
+
+      it 'should only detect two problems' do
+        expect(problems).to have(2).problems
+      end
+
+      it 'should fix the manifest' do
+        expect(problems).to contain_fixed(msg).on_line(1).in_column(2)
+        expect(problems).to contain_fixed(msg).on_line(1).in_column(7)
+      end
+
+      it 'should enclose both variables in braces' do
+        expect(manifest).to eq('"${foo}-${bar}"')
+      end
+    end
   end
 end

--- a/spec/puppet-lint/plugins/check_variables/variable_contains_dash_spec.rb
+++ b/spec/puppet-lint/plugins/check_variables/variable_contains_dash_spec.rb
@@ -34,4 +34,12 @@ describe 'variable_contains_dash' do
       expect(problems).to be_empty
     end
   end
+
+  context 'enclosed variable in a string followed by a dash' do
+    let(:code) { '"${variable}-is-ok"' }
+
+    it 'should not detect any problems' do
+      expect(problems).to be_empty
+    end
+  end
 end


### PR DESCRIPTION
Reimplementation of #500 (which was reverted in #535).

Unlike #500 which removed the ability to parse variable names with dashes, this PR simply changes the regexps that parse the variable names so that they can no longer end with a dash. This allows puppet-lint to correctly detect dash delimited variables (and fix when unenclosed) without creating the false positive from `variable_contains_dash` reported in #504.

Fixes #504