### PR TITLE
Handle mismatched control comments gracefully

### DIFF
--- a/lib/puppet-lint/data.rb
+++ b/lib/puppet-lint/data.rb
@@ -506,10 +506,17 @@ class PuppetLint::Data
               stack_add << [token.line, reason, check]
             end
           else
-            stack.pop.each do |start|
-              unless start.nil?
-                (start[0]..token.line).each do |i|
-                  (ignore_overrides[start[2]] ||= {})[i] = start[1]
+            top_override = stack.pop
+            if top_override.nil?
+              # TODO: refactor to provide a way to expose problems from
+              # PuppetLint::Data via the normal problem reporting mechanism.
+              puts "WARNING: lint:endignore comment with no opening lint:ignore:<check> comment found on line #{token.line}"
+            else
+              top_override.each do |start|
+                unless start.nil?
+                  (start[0]..token.line).each do |i|
+                    (ignore_overrides[start[2]] ||= {})[i] = start[1]
+                  end
                 end
               end
             end

--- a/spec/fixtures/test/manifests/mismatched_control_comment.pp
+++ b/spec/fixtures/test/manifests/mismatched_control_comment.pp
@@ -1,0 +1,1 @@
+# lint:endignore

--- a/spec/puppet-lint/bin_spec.rb
+++ b/spec/puppet-lint/bin_spec.rb
@@ -312,4 +312,13 @@ describe PuppetLint::Bin do
     its(:exitstatus) { is_expected.to eq(0) }
     its(:stdout) { is_expected.to match(/^.*line 6$/) }
   end
+
+  context 'when an lint:endignore control comment exists with no opening lint:ignore comment' do
+    let(:args) { [
+      'spec/fixtures/test/manifests/mismatched_control_comment.pp',
+    ] }
+
+    its(:exitstatus) { is_expected.to eq(0) }
+    its(:stdout) { is_expected.to match(/WARNING: lint:endignore comment with no opening lint:ignore:<check> comment found on line 1/) }
+  end
 end


### PR DESCRIPTION
As reported in #509. If puppet-lint encounters a `lint:endignore` comment that it can't match to `lint:ignore:<check>` comment, it currently throws an exception and dies with a stack trace printed out. This change instead makes it print a friendly warning to the user and then continue on.

Fixes #509