### PR TITLE
Refactor token accessors to use custom getters/setters

### DIFF
--- a/lib/puppet-lint/checkplugin.rb
+++ b/lib/puppet-lint/checkplugin.rb
@@ -59,6 +59,14 @@ class PuppetLint::CheckPlugin
     PuppetLint::Data.tokens
   end
 
+  def tokens=(val)
+    PuppetLint::Data.tokens = val
+  end
+
+  def lexer
+    PuppetLint::Data.lexer
+  end
+  
   # Public: Provides the resource titles to the check plugins.
   #
   # Returns an Array of PuppetLint::Lexer::Token objects.

--- a/lib/puppet-lint/checks.rb
+++ b/lib/puppet-lint/checks.rb
@@ -22,6 +22,7 @@ class PuppetLint::Checks
     PuppetLint::Data.path = path
     PuppetLint::Data.manifest_lines = content.split("\n", -1)
     begin
+      PuppetLint::Data.lexer = lexer
       PuppetLint::Data.tokens = lexer.tokenise(content)
       PuppetLint::Data.parse_control_comments
     rescue PuppetLint::LexerError => e

--- a/lib/puppet-lint/data.rb
+++ b/lib/puppet-lint/data.rb
@@ -12,7 +12,7 @@ class PuppetLint::Data
     attr_reader :path, :fullpath, :filename
 
     # Internal: Get/Set the raw manifest data, split by \n.
-    attr_accessor :manifest_lines
+    attr_accessor :manifest_lines, :lexer
 
     # Internal: Store the tokenised manifest.
     #

--- a/lib/puppet-lint/lexer.rb
+++ b/lib/puppet-lint/lexer.rb
@@ -275,8 +275,7 @@ class PuppetLint
 
       token = Token.new(type, value, line_no, column)
       unless tokens.last.nil?
-        token.prev_token = tokens.last
-        tokens.last.next_token = token
+        tokens.last.next_token = token # next_token= links back
       end
 
       @column += length
@@ -286,6 +285,23 @@ class PuppetLint
       end
 
       token
+    end
+
+    def insert_token(idx, token)
+      unless tokens[idx-1].nil?
+        tokens[idx-1].next_token = token
+      end
+      unless tokens[idx].nil?
+        tokens[idx].prev_token = token
+      end
+      tokens.insert(idx, token)
+    end
+
+    def delete_token(token)
+      idx = tokens.index(token)
+      prev_token = tokens[idx-1]
+      prev_token.next_token = tokens[idx+1]
+      tokens.delete_at(idx)
     end
 
     # Internal: Split a string on multiple terminators, excluding escaped

--- a/lib/puppet-lint/lexer.rb
+++ b/lib/puppet-lint/lexer.rb
@@ -304,6 +304,14 @@ class PuppetLint
       tokens.delete_at(idx)
     end
 
+    def enforce_array
+      tokens.each_with_index do |t, idx|
+        if idx > 1 then
+          tokens[idx-1].next_token = t
+        end
+      end
+    end
+
     # Internal: Split a string on multiple terminators, excluding escaped
     # terminators.
     #

--- a/lib/puppet-lint/lexer.rb
+++ b/lib/puppet-lint/lexer.rb
@@ -277,15 +277,6 @@ class PuppetLint
       unless tokens.last.nil?
         token.prev_token = tokens.last
         tokens.last.next_token = token
-
-        unless FORMATTING_TOKENS.include?(token.type)
-          prev_nf_idx = tokens.rindex { |r| ! FORMATTING_TOKENS.include? r.type }
-          unless prev_nf_idx.nil?
-            prev_nf_token = tokens[prev_nf_idx]
-            prev_nf_token.next_code_token = token
-            token.prev_code_token = prev_nf_token
-          end
-        end
       end
 
       @column += length

--- a/lib/puppet-lint/lexer/token.rb
+++ b/lib/puppet-lint/lexer/token.rb
@@ -13,17 +13,33 @@ class PuppetLint
       attr_accessor :raw
 
       # Public: Returns the Integer line number of the manifest text where the Token can be found.
-      attr_reader :line
+      attr_accessor :line
 
       # Public: Returns the Integer column number of the line of the manifest text where the Token
       # can be found.
-      attr_reader :column
+      attr_accessor :column
 
       # Public: Gets/sets the next token in the manifest.
       attr_reader :next_token
 
       def __next_token=(val)
         @next_token = val
+
+
+        # Walk to the right, updating line and column info
+        prev = self
+        until val.nil? do
+          nl = prev.line + prev.value.lines.length
+          nc = prev.column + prev.value.length
+          if nl == val.line and nc == val.column then
+            break
+          else
+            val.line = nl
+            val.column = nc
+            prev = val
+            val = val.next_token
+          end
+        end
       end
 
       def next_token=(val)
@@ -45,6 +61,11 @@ class PuppetLint
 
       def __prev_token=(val)
         @prev_token = val
+        unless val.nil?
+          @line = val.line + val.value.lines.length
+          @column = val.column + val.value.length
+          self.__next_token = @next_token # to force line/pos recomputation
+        end
       end
 
       def prev_token=(val)

--- a/lib/puppet-lint/lexer/token.rb
+++ b/lib/puppet-lint/lexer/token.rb
@@ -29,7 +29,7 @@ class PuppetLint
         # Walk to the right, updating line and column info
         prev = self
         until val.nil? do
-          nl = prev.line + prev.value.lines.length
+          nl = prev.line + (prev.value.lines.length - 1)
           nc = prev.column + prev.value.length
           if nl == val.line and nc == val.column then
             break
@@ -62,7 +62,7 @@ class PuppetLint
       def __prev_token=(val)
         @prev_token = val
         unless val.nil?
-          @line = val.line + val.value.lines.length
+          @line = val.line + (val.value.lines.length - 1)
           @column = val.column + val.value.length
           self.__next_token = @next_token # to force line/pos recomputation
         end

--- a/lib/puppet-lint/lexer/token.rb
+++ b/lib/puppet-lint/lexer/token.rb
@@ -24,15 +24,28 @@ class PuppetLint
       # Public: Gets/sets the next token in the manifest.
       attr_reader :next_token
 
+      def width
+        return @value.length
+      end
+
+      def height
+        if @type == :NEWLINE then
+          return 1
+        elsif [:WHITESPACE, :COMMENT, :SLASH_COMMENT, :MLCOMMENT, :INDENT].include?(@type) then
+          return @value.lines.length - 1
+        else
+          return 0
+        end
+      end
+
       def __next_token=(val)
         @next_token = val
-
 
         # Walk to the right, updating line and column info
         prev = self
         until val.nil? do
-          nl = prev.line + (prev.value.lines.length - 1)
-          nc = prev.column + prev.value.length
+          nl = prev.line + prev.height
+          nc = prev.type == :NEWLINE ? 1 : prev.column + prev.width
           if nl == val.line and nc == val.column then
             break
           else
@@ -64,8 +77,8 @@ class PuppetLint
       def __prev_token=(val)
         @prev_token = val
         unless val.nil?
-          @line = val.line + (val.value.lines.length - 1)
-          @column = val.column + val.value.length
+          @line = val.line + val.height
+          @column = val.type == :NEWLINE ? 1 : val.column + val.width
           self.__next_token = @next_token # to force line/pos recomputation
         end
       end

--- a/lib/puppet-lint/lexer/token.rb
+++ b/lib/puppet-lint/lexer/token.rb
@@ -26,8 +26,10 @@ class PuppetLint
         if(val != @next_token) then
           t = @next_token
           @next_token = val
-          val.prev_token = self
-          val.next_token = t
+          unless val.nil?
+            val.prev_token = self
+            val.next_token = t
+          end
         end
       end
 
@@ -38,7 +40,11 @@ class PuppetLint
         if(val != @prev_token)
           t = @prev_token
           @prev_token = val
-          t.next_token = val
+          if not t.nil?
+            t.next_token = val
+          else
+            val.next_token = self
+          end
         end
       end
 

--- a/lib/puppet-lint/lexer/token.rb
+++ b/lib/puppet-lint/lexer/token.rb
@@ -1,7 +1,7 @@
 class PuppetLint
   class Lexer
-    # Public: Stores a fragment of the manifest and the information about its
-    # location in the manifest.
+    # Public: Stores a fragment of the manifest and the information about its location in the
+    # manifest.
     class Token
       # Public: Returns the Symbol type of the Token.
       attr_accessor :type
@@ -12,36 +12,61 @@ class PuppetLint
       # Public: Returns the raw value of the Token.
       attr_accessor :raw
 
-      # Public: Returns the Integer line number of the manifest text where
-      # the Token can be found.
+      # Public: Returns the Integer line number of the manifest text where the Token can be found.
       attr_reader :line
 
-      # Public: Returns the Integer column number of the line of the manifest
-      # text where the Token can be found.
+      # Public: Returns the Integer column number of the line of the manifest text where the Token
+      # can be found.
       attr_reader :column
 
       # Public: Gets/sets the next token in the manifest.
-      attr_accessor :next_token
+      attr_reader :next_token
+
+      def next_token=(val)
+        if(val != @next_token) then
+          t = @next_token
+          @next_token = val
+          val.prev_token = self
+          val.next_token = t
+        end
+      end
 
       # Public: Gets/sets the previous token in the manifest.
-      attr_accessor :prev_token
+      attr_reader :prev_token
 
-      # Public: Gets/sets the next code token (skips whitespace, comments,
-      # etc) in the manifest.
-      attr_accessor :next_code_token
+      def prev_token=(val)
+        if(val != @prev_token)
+          t = @prev_token
+          @prev_token = val
+          t.next_token = val
+        end
+      end
 
-      # Public: Gets/sets the previous code tokne (skips whitespace,
-      # comments, etc) in the manifest.
-      attr_accessor :prev_code_token
+      # Public: Gets the next code token (skips whitespace, comments, etc) in the manifest.
+      def next_code_token
+        t = @next_token
+        while t and t.whitespace?
+          t = t.next_token
+        end
+        return t
+      end
+
+      # Public: Gets the previous code token (skips whitespace, comments, etc) in the manifest.
+      def prev_code_token
+        t = @prev_token
+        while t and t.whitespace?
+          t = t.prev_token
+        end
+        return t
+      end
 
       # Public: Initialise a new Token object.
       #
       # type   - An upper case Symbol describing the type of Token.
       # value  - The String value of the Token.
-      # line   - The Integer line number where the Token can be found in the
-      #          manifest.
-      # column - The Integer number of characters from the start of the line to
-      #          the start of the Token.
+      # line   - The Integer line number where the Token can be found in the manifest.
+      # column - The Integer number of characters from the start of the line to the start of the
+      #          Token.
       #
       # Returns the instantiated Token.
       def initialize(type, value, line, column)
@@ -55,8 +80,7 @@ class PuppetLint
         @prev_code_token = nil
       end
 
-      # Public: Produce a human friendly description of the Token when
-      # inspected.
+      # Public: Produce a human friendly description of the Token when inspected.
       #
       # Returns a String describing the Token.
       def inspect
@@ -95,6 +119,10 @@ class PuppetLint
         else
           @value
         end
+      end
+
+      def whitespace?
+        return PuppetLint::Lexer.FORMATTING_TOKENS.fetch(@type, false)
       end
     end
   end

--- a/lib/puppet-lint/lexer/token.rb
+++ b/lib/puppet-lint/lexer/token.rb
@@ -122,7 +122,7 @@ class PuppetLint
       end
 
       def whitespace?
-        return PuppetLint::Lexer.FORMATTING_TOKENS.fetch(@type, false)
+        return PuppetLint::Lexer::FORMATTING_TOKENS.fetch(@type, false)
       end
     end
   end

--- a/lib/puppet-lint/lexer/token.rb
+++ b/lib/puppet-lint/lexer/token.rb
@@ -56,6 +56,7 @@ class PuppetLint
           end
           unless val.nil?
             val.__next_token = self
+            val.__prev_token = t
           end
         end
       end

--- a/lib/puppet-lint/lexer/token.rb
+++ b/lib/puppet-lint/lexer/token.rb
@@ -120,7 +120,7 @@ class PuppetLint
         when :DQPOST
           "#{@value}\""
         when :VARIABLE
-          if !@prev_code_token.nil? && [:DQPRE, :DQMID].include?(@prev_code_token.type)
+          if !prev_code_token.nil? && [:DQPRE, :DQMID].include?(prev_code_token.type)
             "${#{@value}}"
           else
             "$#{@value}"

--- a/lib/puppet-lint/lexer/token.rb
+++ b/lib/puppet-lint/lexer/token.rb
@@ -22,13 +22,20 @@ class PuppetLint
       # Public: Gets/sets the next token in the manifest.
       attr_reader :next_token
 
+      def __next_token=(val)
+        @next_token = val
+      end
+
       def next_token=(val)
         if(val != @next_token) then
           t = @next_token
           @next_token = val
           unless val.nil?
-            val.prev_token = self
-            val.next_token = t
+            val.__prev_token = self
+            val.__next_token = t
+          end
+          unless t.nil?
+            t.__prev_token = val
           end
         end
       end
@@ -36,14 +43,19 @@ class PuppetLint
       # Public: Gets/sets the previous token in the manifest.
       attr_reader :prev_token
 
+      def __prev_token=(val)
+        @prev_token = val
+      end
+
       def prev_token=(val)
         if(val != @prev_token)
           t = @prev_token
           @prev_token = val
-          if not t.nil?
-            t.next_token = val
-          else
-            val.next_token = self
+          unless t.nil?
+            t.__next_token = val
+          end
+          unless val.nil?
+            val.__next_token = self
           end
         end
       end

--- a/lib/puppet-lint/plugins/check_comments.rb
+++ b/lib/puppet-lint/plugins/check_comments.rb
@@ -45,9 +45,9 @@ PuppetLint.new_check(:star_comments) do
     index = tokens.index(problem[:token].next_token) || 1
     comment_lines.reverse.each do |line|
       indent = problem[:token].prev_token.nil? ? nil : problem[:token].prev_token.value.dup
-      insert_token(index, PuppetLint::Lexer::Token.new(:COMMENT, " #{line}", 0, 0))
-      insert_token(index, PuppetLint::Lexer::Token.new(:INDENT, indent, 0, 0)) if indent
-      insert_token(index, PuppetLint::Lexer::Token.new(:NEWLINE, "\n", 0, 0))
+      lexer.insert_token(index, PuppetLint::Lexer::Token.new(:COMMENT, " #{line}", 0, 0))
+      lexer.insert_token(index, PuppetLint::Lexer::Token.new(:INDENT, indent, 0, 0)) if indent
+      lexer.insert_token(index, PuppetLint::Lexer::Token.new(:NEWLINE, "\n", 0, 0))
     end
   end
 end

--- a/lib/puppet-lint/plugins/check_comments.rb
+++ b/lib/puppet-lint/plugins/check_comments.rb
@@ -45,9 +45,9 @@ PuppetLint.new_check(:star_comments) do
     index = tokens.index(problem[:token].next_token) || 1
     comment_lines.reverse.each do |line|
       indent = problem[:token].prev_token.nil? ? nil : problem[:token].prev_token.value.dup
-      tokens.insert(index, PuppetLint::Lexer::Token.new(:COMMENT, " #{line}", 0, 0))
-      tokens.insert(index, PuppetLint::Lexer::Token.new(:INDENT, indent, 0, 0)) if indent
-      tokens.insert(index, PuppetLint::Lexer::Token.new(:NEWLINE, "\n", 0, 0))
+      insert_token(index, PuppetLint::Lexer::Token.new(:COMMENT, " #{line}", 0, 0))
+      insert_token(index, PuppetLint::Lexer::Token.new(:INDENT, indent, 0, 0)) if indent
+      insert_token(index, PuppetLint::Lexer::Token.new(:NEWLINE, "\n", 0, 0))
     end
   end
 end

--- a/lib/puppet-lint/plugins/check_conditionals.rb
+++ b/lib/puppet-lint/plugins/check_conditionals.rb
@@ -50,7 +50,7 @@ PuppetLint.new_check(:case_without_default) do
       case_tokens = tokens[kase[:start]..kase[:end]]
 
       case_indexes[(kase_index + 1)..-1].each do |successor_kase|
-	case_tokens -= tokens[successor_kase[:start]..successor_kase[:end]]
+	      case_tokens -= tokens[successor_kase[:start]..successor_kase[:end]]
       end
 
       unless case_tokens.index { |r| r.type == :DEFAULT }

--- a/lib/puppet-lint/plugins/check_resources.rb
+++ b/lib/puppet-lint/plugins/check_resources.rb
@@ -98,10 +98,10 @@ PuppetLint.new_check(:ensure_first_param) do
     ensure_tmp = tokens.slice!(ensure_param_name_idx..ensure_param_comma_idx-1)
     first_tmp = tokens.slice!(first_param_name_idx..first_param_comma_idx-1)
     ensure_tmp.reverse_each do |item|
-      tokens.insert(first_param_name_idx, item)
+      PuppetLint::Lexer.insert_token(first_param_name_idx, item)
     end
     first_tmp.reverse_each do |item|
-      tokens.insert(ensure_param_name_idx + ensure_tmp.length - first_tmp.length, item)
+      PuppetLint::Lexer.insert_token(ensure_param_name_idx + ensure_tmp.length - first_tmp.length, item)
     end
   end
 end
@@ -251,7 +251,7 @@ PuppetLint.new_check(:ensure_not_symlink_target) do
       PuppetLint::Lexer::Token.new(:FARROW, '=>', 0, 0),
       PuppetLint::Lexer::Token.new(:WHITESPACE, ' ', 0, 0),
     ].reverse.each do |new_token|
-      tokens.insert(index, new_token)
+      PuppetLint::Lexer.insert_token(index, new_token)
     end
   end
 end

--- a/lib/puppet-lint/plugins/check_resources.rb
+++ b/lib/puppet-lint/plugins/check_resources.rb
@@ -69,7 +69,7 @@ PuppetLint.new_check(:ensure_first_param) do
           ensure_param_name_token = token
           ensure_param_name_idx = problem[:resource][:start] + token_idx
         end
-      elsif ensure_param_comma_token.nil?
+      elsif !ensure_param_name_token.nil? and ensure_param_comma_token.nil?
         if token.type == :COMMA or token.type == :SEMIC
           ensure_param_comma_token = token
           ensure_param_comma_idx = problem[:resource][:start] + token_idx
@@ -80,29 +80,22 @@ PuppetLint.new_check(:ensure_first_param) do
     if first_param_name_token.nil? or first_param_comma_token.nil? or ensure_param_name_token.nil? or ensure_param_comma_token.nil?
       raise PuppetLint::NoFix
     end
-    # Flip params
-    prev_token = first_param_name_token.prev_token
-    first_param_name_token.prev_token = ensure_param_name_token.prev_token
-    ensure_param_name_token.prev_token = prev_token
+    head = tokens[0..first_param_name_idx-1]
+    namec = tokens[first_param_name_idx..first_param_comma_idx]
+    middle = tokens[(first_param_comma_idx+1)..(ensure_param_name_idx-1)]
+    ensurec = tokens[ensure_param_name_idx..ensure_param_comma_idx]
+    tail = tokens[(ensure_param_comma_idx+1)..-1]
+    
+    ntokens = head + ensurec + middle + namec + tail
 
-    prev_code_token = first_param_name_token.prev_code_token
-
-    next_token = first_param_comma_token.next_token
-    first_param_comma_token = ensure_param_comma_token.next_token
-    ensure_param_comma_token.next_token = next_token
-
-    next_code_token = first_param_comma_token.next_code_token
-    first_param_comma_code_token = ensure_param_comma_token.next_code_token
-
-    # Update index
-    ensure_tmp = tokens.slice!(ensure_param_name_idx..ensure_param_comma_idx-1)
-    first_tmp = tokens.slice!(first_param_name_idx..first_param_comma_idx-1)
-    ensure_tmp.reverse_each do |item|
-      insert_token(first_param_name_idx, item)
+    ntokens.each_with_index do |t, i|
+      tokens[i] = t
     end
-    first_tmp.reverse_each do |item|
-      insert_token(ensure_param_name_idx + ensure_tmp.length - first_tmp.length, item)
-    end
+    
+    head.last.next_token = ensurec.first
+    ensurec.last.next_token = namec.first
+    namec.last.next_token = middle.first
+    middle.last.next_token = tail.first
   end
 end
 
@@ -251,7 +244,7 @@ PuppetLint.new_check(:ensure_not_symlink_target) do
       PuppetLint::Lexer::Token.new(:FARROW, '=>', 0, 0),
       PuppetLint::Lexer::Token.new(:WHITESPACE, ' ', 0, 0),
     ].reverse.each do |new_token|
-      insert_token(index, new_token)
+      lexer.insert_token(index, new_token)
     end
   end
 end

--- a/lib/puppet-lint/plugins/check_resources.rb
+++ b/lib/puppet-lint/plugins/check_resources.rb
@@ -98,10 +98,10 @@ PuppetLint.new_check(:ensure_first_param) do
     ensure_tmp = tokens.slice!(ensure_param_name_idx..ensure_param_comma_idx-1)
     first_tmp = tokens.slice!(first_param_name_idx..first_param_comma_idx-1)
     ensure_tmp.reverse_each do |item|
-      PuppetLint::Lexer.insert_token(first_param_name_idx, item)
+      insert_token(first_param_name_idx, item)
     end
     first_tmp.reverse_each do |item|
-      PuppetLint::Lexer.insert_token(ensure_param_name_idx + ensure_tmp.length - first_tmp.length, item)
+      insert_token(ensure_param_name_idx + ensure_tmp.length - first_tmp.length, item)
     end
   end
 end
@@ -251,7 +251,7 @@ PuppetLint.new_check(:ensure_not_symlink_target) do
       PuppetLint::Lexer::Token.new(:FARROW, '=>', 0, 0),
       PuppetLint::Lexer::Token.new(:WHITESPACE, ' ', 0, 0),
     ].reverse.each do |new_token|
-      PuppetLint::Lexer.insert_token(index, new_token)
+      insert_token(index, new_token)
     end
   end
 end

--- a/lib/puppet-lint/plugins/check_resources.rb
+++ b/lib/puppet-lint/plugins/check_resources.rb
@@ -95,7 +95,6 @@ PuppetLint.new_check(:ensure_first_param) do
 
     next_code_token = first_param_comma_token.next_code_token
     first_param_comma_code_token = ensure_param_comma_token.next_code_token
-    ensure_param_comma_token.next_code_token = next_code_token
 
     # Update index
     ensure_tmp = tokens.slice!(ensure_param_name_idx..ensure_param_comma_idx-1)

--- a/lib/puppet-lint/plugins/check_resources.rb
+++ b/lib/puppet-lint/plugins/check_resources.rb
@@ -86,8 +86,6 @@ PuppetLint.new_check(:ensure_first_param) do
     ensure_param_name_token.prev_token = prev_token
 
     prev_code_token = first_param_name_token.prev_code_token
-    first_param_name_token.prev_code_token = ensure_param_name_token.prev_code_token
-    ensure_param_name_token.prev_code_token = prev_code_token
 
     next_token = first_param_comma_token.next_token
     first_param_comma_token = ensure_param_comma_token.next_token

--- a/lib/puppet-lint/plugins/check_strings.rb
+++ b/lib/puppet-lint/plugins/check_strings.rb
@@ -65,8 +65,8 @@ PuppetLint.new_check(:only_variable_string) do
   end
 
   def fix(problem)
-    delete_token(problem[:start_token])
-    delete_token(problem[:end_token])
+    lexer.delete_token(problem[:start_token])
+    lexer.delete_token(problem[:end_token])
 
     var_token = problem[:var_token]
     var_token.type = :VARIABLE

--- a/lib/puppet-lint/plugins/check_strings.rb
+++ b/lib/puppet-lint/plugins/check_strings.rb
@@ -75,13 +75,9 @@ PuppetLint.new_check(:only_variable_string) do
     tokens.delete(problem[:end_token])
 
     prev_token.next_token = var_token unless prev_token.nil?
-    prev_code_token.next_code_token = var_token unless prev_code_token.nil?
-    next_code_token.prev_code_token = var_token unless next_code_token.nil?
     next_token.prev_token = var_token unless next_token.nil?
     var_token.type = :VARIABLE
     var_token.next_token = next_token
-    var_token.next_code_token = next_code_token
-    var_token.prev_code_token = prev_code_token
     var_token.prev_token = prev_token
   end
 end

--- a/lib/puppet-lint/plugins/check_strings.rb
+++ b/lib/puppet-lint/plugins/check_strings.rb
@@ -65,20 +65,11 @@ PuppetLint.new_check(:only_variable_string) do
   end
 
   def fix(problem)
-    prev_token = problem[:start_token].prev_token
-    prev_code_token = problem[:start_token].prev_code_token
-    next_token = problem[:end_token].next_token
-    next_code_token = problem[:end_token].next_code_token
+    delete_token(problem[:start_token])
+    delete_token(problem[:end_token])
+
     var_token = problem[:var_token]
-
-    tokens.delete(problem[:start_token])
-    tokens.delete(problem[:end_token])
-
-    prev_token.next_token = var_token unless prev_token.nil?
-    next_token.prev_token = var_token unless next_token.nil?
     var_token.type = :VARIABLE
-    var_token.next_token = next_token
-    var_token.prev_token = prev_token
   end
 end
 

--- a/lib/puppet-lint/plugins/check_whitespace.rb
+++ b/lib/puppet-lint/plugins/check_whitespace.rb
@@ -40,7 +40,7 @@ PuppetLint.new_check(:trailing_whitespace) do
   end
 
   def fix(problem)
-    delete_token(problem[:token])
+    lexer.delete_token(problem[:token])
   end
 end
 
@@ -169,7 +169,7 @@ PuppetLint.new_check(:arrow_alignment) do
       index = tokens.index(problem[:token].prev_code_token.prev_token)
 
       #insert newline
-      insert_token(index, PuppetLint::Lexer::Token.new(:NEWLINE, "\n", 0, 0))
+      lexer.insert_token(index, PuppetLint::Lexer::Token.new(:NEWLINE, "\n", 0, 0))
 
       # indent the parameter to the correct depth
       problem[:token].prev_code_token.prev_token.type = :INDENT
@@ -180,7 +180,7 @@ PuppetLint.new_check(:arrow_alignment) do
       problem[:token].prev_token.value = new_ws
     else
       index = tokens.index(problem[:token].prev_token)
-      insert_token(index + 1, PuppetLint::Lexer::Token.new(:WHITESPACE, new_ws, 0, 0))
+      lexer.insert_token(index + 1, PuppetLint::Lexer::Token.new(:WHITESPACE, new_ws, 0, 0))
     end
   end
 end

--- a/lib/puppet-lint/plugins/check_whitespace.rb
+++ b/lib/puppet-lint/plugins/check_whitespace.rb
@@ -40,11 +40,7 @@ PuppetLint.new_check(:trailing_whitespace) do
   end
 
   def fix(problem)
-    prev_token = problem[:token].prev_token
-    next_token = problem[:token].next_token
-    prev_token.next_token = next_token
-    next_token.prev_token = prev_token unless next_token.nil?
-    tokens.delete(problem[:token])
+    delete_token(problem[:token])
   end
 end
 
@@ -173,7 +169,7 @@ PuppetLint.new_check(:arrow_alignment) do
       index = tokens.index(problem[:token].prev_code_token.prev_token)
 
       #insert newline
-      tokens.insert(index, PuppetLint::Lexer::Token.new(:NEWLINE, "\n", 0, 0))
+      insert_token(index, PuppetLint::Lexer::Token.new(:NEWLINE, "\n", 0, 0))
 
       # indent the parameter to the correct depth
       problem[:token].prev_code_token.prev_token.type = :INDENT
@@ -184,7 +180,7 @@ PuppetLint.new_check(:arrow_alignment) do
       problem[:token].prev_token.value = new_ws
     else
       index = tokens.index(problem[:token].prev_token)
-      tokens.insert(index + 1, PuppetLint::Lexer::Token.new(:WHITESPACE, new_ws, 0, 0))
+      insert_token(index + 1, PuppetLint::Lexer::Token.new(:WHITESPACE, new_ws, 0, 0))
     end
   end
 end


### PR DESCRIPTION
This patch rewrites {prev,next}(_code)?_token so that they should be more repeatable and will
preserve the structure invariants in the tokens linked list.

Because {prev,next}_code_token are just views on {prev,next}_token, they no longer have setters and are implemented as linked list traversals on the corresponding token link.

Because users can't be trusted to set up links in the list, the {prev,next}_token= setters now
automatically fix the prev and next links of all tokens involved. This should make splicing new
tokens in easier.

Note - this patch does not provide automatic propagation of changes to line and column number. Those things still need to be implemented. Probably by some push method.