### PR TITLE
(#544, #537) Skip hash contents when checking optional parameters

### DIFF
--- a/lib/puppet-lint/plugins/check_classes.rb
+++ b/lib/puppet-lint/plugins/check_classes.rb
@@ -103,12 +103,18 @@ PuppetLint.new_check(:parameter_order) do
     (class_indexes + defined_type_indexes).each do |class_idx|
       unless class_idx[:param_tokens].nil?
         paren_stack = []
+        hash_stack = []
         class_idx[:param_tokens].each_with_index do |token, i|
           if token.type == :LPAREN
             paren_stack.push(true)
           elsif token.type == :RPAREN
             paren_stack.pop
+          elsif token.type == :LBRACE
+            hash_stack.push(true)
+          elsif token.type == :RBRACE
+            hash_stack.pop
           end
+          next if (! hash_stack.empty?)
           next unless paren_stack.empty?
 
           if token.type == :VARIABLE

--- a/lib/puppet-lint/plugins/check_classes.rb
+++ b/lib/puppet-lint/plugins/check_classes.rb
@@ -103,18 +103,18 @@ PuppetLint.new_check(:parameter_order) do
     (class_indexes + defined_type_indexes).each do |class_idx|
       unless class_idx[:param_tokens].nil?
         paren_stack = []
-        hash_stack = []
+        hash_or_array_stack = []
         class_idx[:param_tokens].each_with_index do |token, i|
           if token.type == :LPAREN
             paren_stack.push(true)
           elsif token.type == :RPAREN
             paren_stack.pop
-          elsif token.type == :LBRACE
-            hash_stack.push(true)
-          elsif token.type == :RBRACE
-            hash_stack.pop
+          elsif token.type == :LBRACE || token.type == :LBRACK
+            hash_or_array_stack.push(true)
+          elsif token.type == :RBRACE || token.type == :RBRACK
+            hash_or_array_stack.pop
           end
-          next if (! hash_stack.empty?)
+          next if (! hash_or_array_stack.empty?)
           next unless paren_stack.empty?
 
           if token.type == :VARIABLE

--- a/spec/puppet-lint/plugins/check_classes/parameter_order_spec.rb
+++ b/spec/puppet-lint/plugins/check_classes/parameter_order_spec.rb
@@ -74,11 +74,11 @@ describe 'parameter_order' do
       end
     end
 
-    context 'mandatory parameter w/a hash containing a variable and no optional parameters' do
+    context "#{type} parameter w/a hash containing a variable and no optional parameters" do
       let(:code) { "
         $var1 = 'test'
         
-        class test (
+        #{type} test (
           $entries = {
             '200 xxx' => {
               param1 => $var1,
@@ -87,19 +87,17 @@ describe 'parameter_order' do
             }
           },
           $mandatory => undef,
-        ) {
-          notice $entries
-        }
+        ) { }
       "}
 
       it { expect(problems).to have(0).problem }
     end
 
-    context 'mandatory parameter w/a hash containing a variable followed by an optional parameter' do
+    context "#{type} parameter w/a hash containing a variable followed by an optional parameter" do
       let(:code) { "
         $var1 = 'test'
         
-        class test (
+        #{type} test (
           $entries = {
             '200 xxx' => {
               param1 => $var1,
@@ -109,12 +107,20 @@ describe 'parameter_order' do
           },
           $optional,
           $mandatory => undef,
-        ) {
-          notice $entries
-        }
+        ) { }
       "}
 
       it { expect(problems).to contain_warning(msg).on_line(12).in_column(11) }
+    end
+
+    context "#{type} parameter w/array containing a variable" do
+      let(:code) {"
+        #{type} test (
+          $var1 = [$::hostname, 'host'],
+        ) { }
+      "}
+
+      it { expect(problems).to have(0).problem }
     end
   end
 end

--- a/spec/puppet-lint/plugins/check_classes/parameter_order_spec.rb
+++ b/spec/puppet-lint/plugins/check_classes/parameter_order_spec.rb
@@ -73,5 +73,48 @@ describe 'parameter_order' do
         expect(problems).to have(0).problems
       end
     end
+
+    context 'mandatory parameter w/a hash containing a variable and no optional parameters' do
+      let(:code) { "
+        $var1 = 'test'
+        
+        class test (
+          $entries = {
+            '200 xxx' => {
+              param1 => $var1,
+              param2 => 'value2',
+              param3 => 'value3',
+            }
+          },
+          $mandatory => undef,
+        ) {
+          notice $entries
+        }
+      "}
+
+      it { expect(problems).to have(0).problem }
+    end
+
+    context 'mandatory parameter w/a hash containing a variable followed by an optional parameter' do
+      let(:code) { "
+        $var1 = 'test'
+        
+        class test (
+          $entries = {
+            '200 xxx' => {
+              param1 => $var1,
+              param2 => 'value2',
+              param3 => 'value3',
+            }
+          },
+          $optional,
+          $mandatory => undef,
+        ) {
+          notice $entries
+        }
+      "}
+
+      it { expect(problems).to contain_warning(msg).on_line(12).in_column(11) }
+    end
   end
 end


### PR DESCRIPTION
Fixes #544 
Fixes #537 