### PR TITLE
(#517) Update the allowed tokens prior to a regex

### DIFF
--- a/lib/puppet-lint/lexer.rb
+++ b/lib/puppet-lint/lexer.rb
@@ -81,6 +81,8 @@ class PuppetLint
       :NOMATCH => true,
       :COMMA   => true,
       :LBRACK  => true,
+      :IF      => true,
+      :ELSIF   => true,
     }
 
     # Internal: An Array of Arrays containing tokens that can be described by

--- a/spec/puppet-lint/lexer_spec.rb
+++ b/spec/puppet-lint/lexer_spec.rb
@@ -840,6 +840,17 @@ describe PuppetLint::Lexer do
       tokens = @lexer.tokenise('$x = $a/$b/$c')
       expect(tokens.select { |r| r.type == :REGEX }).to be_empty
     end
+
+    it 'should properly parse when regex follows an if' do
+      tokens = @lexer.tokenise('if /^icinga_service_icon_.*/ in $location_info { }')
+      expect(tokens[2].type).to eq(:REGEX)
+    end
+
+    it 'should properly parse when a regex follows an elsif' do
+      tokens = @lexer.tokenise('if /a/ in $location_info { } elsif /b/ in $location_info { }')
+      expect(tokens[2].type).to eq(:REGEX)
+      expect(tokens[14].type).to eq(:REGEX)
+    end
   end
 
   context ':STRING' do


### PR DESCRIPTION
Fixes #517 
I am not aware of other tokens besides `if`/`elsif` that are permitted and not currently allowed. Please let me know if there are.