### PR TITLE
Ignore *.pp files at the top level

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ coverage/
 *.swp
 /_site/
 .idea
+/*.pp


### PR DESCRIPTION
I tend to create .pp files with manifests from issues for testing. This prevents .pp files in other directories (like `spec/fixtures/test/manifests`) from being ignored, though.