### PR TITLE
Backwards incompatible change: Drop Ruby 1.8 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ branches:
     - master
 bundler_args: --without development system_tests
 rvm:
-  - 1.8.7
   - 1.9.3
   - 2.0.0
   - 2.1.9

--- a/Gemfile
+++ b/Gemfile
@@ -7,27 +7,23 @@ group :test do
   gem 'rspec', '~> 3.0'
   gem 'rspec-its', '~> 1.0'
   gem 'rspec-collection_matchers', '~> 1.0'
+  gem 'rspec-json_expectations', '~> 1.4'
 
   if RUBY_VERSION < '2.0'
     # json 2.x requires ruby 2.0. Lock to 1.8
     gem 'json', '= 1.8'
-    # json_pure 2.0.2 requires ruby 2.0, and 2.0.1 requires ruby 1.9. Lock to 1.8.3.
-    gem 'json_pure', '= 1.8.3'
-    # addressable 2.4.0 requires ruby 1.9.0. Lock to 2.3.8.
+    # json_pure 2.0.2 requires ruby 2.0. Lock to 2.0.1
+    gem 'json_pure', '= 2.0.1'
+    # addressable 2.4.0 requires ruby 1.9.0. Lock to 2.3.8
     gem 'addressable', '= 2.3.8'
   else
     gem 'json'
-  end
-  
-  if RUBY_VERSION > '1.8'
-    # requires ruby 1.9+, on 1.8 we'll fall back to the old regex parsing
-    gem 'rspec-json_expectations', '~> 1.4'
   end
 end
 
 group :development do
   # For Changelog generation
   gem 'github_changelog_generator',                                 :require => false if RUBY_VERSION >= '2.2.2'
-  gem 'github_changelog_generator', '~> 1.13.0',                    :require => false if RUBY_VERSION < '2.2.2'
-  gem 'rack', '~> 1.0',                                             :require => false if RUBY_VERSION < '2.2.2'
+  gem 'github_changelog_generator', '~> 1.13.0',                    :require => false if RUBY_VERSION <  '2.2.2'
+  gem 'rack', '~> 1.0',                                             :require => false if RUBY_VERSION <  '2.2.2'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,11 +1,7 @@
 require 'puppet-lint'
 require 'rspec/its'
 require 'rspec/collection_matchers'
-begin
-  require 'rspec/json_expectations'
-rescue SyntaxError
-  puts 'rspec/json_expectations is not available'
-end
+require 'rspec/json_expectations'
 
 module RSpec
   module LintExampleGroup


### PR DESCRIPTION
Per #503