### PR TITLE
Calculate arrow column from first parameter position, not the start of the line

### DIFF
--- a/lib/puppet-lint/plugins/check_whitespace.rb
+++ b/lib/puppet-lint/plugins/check_whitespace.rb
@@ -128,6 +128,7 @@ PuppetLint.new_check(:arrow_alignment) do
       indent_depth = [0]
       indent_depth_idx = 0
       level_tokens = []
+      param_column = [nil]
       resource_tokens = res_idx[:tokens]
       resource_tokens.reject! do |token|
         COMMENT_TYPES.include? token.type
@@ -143,9 +144,13 @@ PuppetLint.new_check(:arrow_alignment) do
       resource_tokens.each_with_index do |token, idx|
         if token.type == :FARROW
           (level_tokens[indent_depth_idx] ||= []) << token
-          prev_indent_token = resource_tokens[0..idx].rindex { |t| t.type == :INDENT }
-          indent_token_length = prev_indent_token.nil? ? 0 : resource_tokens[prev_indent_token].to_manifest.length
-          indent_length = indent_token_length + token.prev_code_token.to_manifest.length + 2
+          param_token = token.prev_code_token
+
+          if param_column[indent_depth_idx].nil?
+            param_column[indent_depth_idx] = param_token.column
+          end
+
+          indent_length = param_column[indent_depth_idx] + param_token.to_manifest.length + 1
 
           if indent_depth[indent_depth_idx] < indent_length
             indent_depth[indent_depth_idx] = indent_length
@@ -155,6 +160,7 @@ PuppetLint.new_check(:arrow_alignment) do
           indent_depth_idx += 1
           indent_depth << 0
           level_tokens[indent_depth_idx] ||= []
+          param_column << nil
         elsif token.type == :RBRACE || token.type == :SEMIC
           level_tokens[indent_depth_idx].each do |arrow_tok|
             unless arrow_tok.column == indent_depth[indent_depth_idx] || level_tokens[indent_depth_idx].size == 1
@@ -166,7 +172,7 @@ PuppetLint.new_check(:arrow_alignment) do
                 :token          => arrow_tok,
                 :indent_depth   => indent_depth[indent_depth_idx],
                 :newline        => !(arrows_on_line.index(arrow_tok) == 0),
-                :newline_indent => arrows_on_line.first.prev_code_token.prev_token.value,
+                :newline_indent => param_column[indent_depth_idx] - 1,
               }
             end
           end
@@ -179,7 +185,7 @@ PuppetLint.new_check(:arrow_alignment) do
   end
 
   def fix(problem)
-    new_ws_len = (problem[:indent_depth] - (problem[:newline_indent].length + problem[:token].prev_code_token.to_manifest.length + 1))
+    new_ws_len = (problem[:indent_depth] - (problem[:newline_indent] + problem[:token].prev_code_token.to_manifest.length + 1))
     new_ws = ' ' * new_ws_len
     if problem[:newline]
       index = tokens.index(problem[:token].prev_code_token.prev_token)
@@ -189,7 +195,7 @@ PuppetLint.new_check(:arrow_alignment) do
 
       # indent the parameter to the correct depth
       problem[:token].prev_code_token.prev_token.type = :INDENT
-      problem[:token].prev_code_token.prev_token.value = problem[:newline_indent].dup
+      problem[:token].prev_code_token.prev_token.value = ' ' * problem[:newline_indent]
     end
 
     if problem[:token].prev_token.type == :WHITESPACE

--- a/spec/puppet-lint/plugins/check_whitespace/arrow_alignment_spec.rb
+++ b/spec/puppet-lint/plugins/check_whitespace/arrow_alignment_spec.rb
@@ -346,6 +346,25 @@ describe 'arrow_alignment' do
         expect(problems).to have(0).problems
       end
     end
+
+    context 'unaligned multiline hash with opening brace on the same line as the first pair' do
+      let(:code) { "
+        foo { 'foo':
+          bar => [
+            { aa => bb,
+              c => d},
+          ],
+        }
+      " }
+
+      it 'should detect one problem' do
+        expect(problems).to have(1).problem
+      end
+
+      it 'should create one warning' do
+        expect(problems).to contain_warning(sprintf(msg,18,17)).on_line(5).in_column(17)
+      end
+    end
   end
 
   context 'with fix enabled' do

--- a/spec/puppet-lint/plugins/check_whitespace/arrow_alignment_spec.rb
+++ b/spec/puppet-lint/plugins/check_whitespace/arrow_alignment_spec.rb
@@ -332,6 +332,20 @@ describe 'arrow_alignment' do
       end
     end
 
+    context 'multiline hash with opening brace on same line as first pair' do
+      let(:code) { "
+        foo { 'foo':
+          bar => [
+            { aa => bb,
+              c  => d},
+          ],
+        }
+      " }
+
+      it 'should not detect any problems' do
+        expect(problems).to have(0).problems
+      end
+    end
   end
 
   context 'with fix enabled' do


### PR DESCRIPTION
This changes the logic used in the `arrow_alignment` check to determine the correct column number for each `=>`. Previously, this was calculated by finding the previous `:INDENT` token and using the length of this token plus all the parameter tokens to determine the correct column to put the arrows in.

Unfortunately, this approach causes [false positives](https://github.com/rodjek/puppet-lint/issue/333) for people who put their opening braces on the same line as their first key-value:

```
{ foo => bar,
  baz => qux }
```
The new logic works similarly to the old way, except instead of using the previous `:INDENT` token, we now use the column number of the first parameter token in the block as the base value.

Fixes #333