### PR TITLE
Support array of variables on left side of an assign operation

### DIFF
--- a/lib/puppet-lint/plugins/check_classes.rb
+++ b/lib/puppet-lint/plugins/check_classes.rb
@@ -298,17 +298,27 @@ PuppetLint.new_check(:variable_scope) do
       temp_scope_vars = []
 
       object_tokens.each do |token|
-        if token.type == :VARIABLE
+        case token.type
+        when :EQUALS
+          if token.prev_code_token.type == :VARIABLE
+            variables_in_scope << token.prev_code_token.value
+          elsif token.prev_code_token.type == :RBRACK
+            temp_token = token.prev_code_token
+
+            until temp_token.type == :LBRACK do
+              if temp_token.type == :VARIABLE
+                variables_in_scope << temp_token.value
+              end
+              temp_token = temp_token.prev_code_token
+            end
+          end
+        when :VARIABLE
           if in_pipe
             temp_scope_vars << token.value
           else
-            if token.next_code_token.type == :EQUALS
-              variables_in_scope << token.value
-            else
-              referenced_variables << token
-            end
+            referenced_variables << token
           end
-        elsif token.type == :PIPE
+        when :PIPE
           in_pipe = !in_pipe
 
           if in_pipe

--- a/spec/puppet-lint/plugins/check_classes/variable_scope_spec.rb
+++ b/spec/puppet-lint/plugins/check_classes/variable_scope_spec.rb
@@ -196,4 +196,16 @@ describe 'variable_scope' do
       expect(problems).to have(0).problems
     end
   end
+
+  context 'multiple left hand variable assign' do
+    let(:code) { "
+      class test {
+        [$foo, $bar] = something()
+      }
+    " }
+
+    it 'should not detect any problems' do
+      expect(problems).to have(0).problems
+    end
+  end
 end


### PR DESCRIPTION
Multiple variables can now be assigned by using an array on the left hand side of an operation, e.g.
```puppet
[$foo, $bar] = split('baz qux', ' ')
```
This PR changes the logic for the `variable_scope` check so that when it encounters such a case, all the variable names in the array are marked as being in scope.

Fixes #550