### PR TITLE
Add LoadError to fix broken tests

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,7 +3,7 @@ require 'rspec/its'
 require 'rspec/collection_matchers'
 begin
   require 'rspec/json_expectations'
-rescue SyntaxError
+rescue LoadError, SyntaxError
   puts 'rspec/json_expectations is not available'
 end
 


### PR DESCRIPTION
Tests for a plugin was not passing because of this error:
```
/var/lib/gems/2.3.0/gems/puppet-lint-2.1.1/spec/spec_helper.rb:5:in `require': cannot load such file -- rspec/json_expectations (LoadError)
	from /var/lib/gems/2.3.0/gems/puppet-lint-2.1.1/spec/spec_helper.rb:5:in `<top (required)>'
	from /var/lib/gems/2.3.0/gems/puppet-lint-2.1.1/lib/puppet-lint/plugins.rb:28:in `load'
	from /var/lib/gems/2.3.0/gems/puppet-lint-2.1.1/lib/puppet-lint/plugins.rb:28:in `load_spec_helper'
	from /home/damoreno/playground/git/damoreno-lint/spec/spec_helper.rb:8:in `<top (required)>'
	from /home/damoreno/playground/git/damoreno-lint/spec/puppet-lint/plugins/check_version_comparison/version_comparison_spec.rb:1:in `require'
	from /home/damoreno/playground/git/damoreno-lint/spec/puppet-lint/plugins/check_version_comparison/version_comparison_spec.rb:1:in `<top (required)>'
	from /var/lib/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/configuration.rb:1435:in `load'
	from /var/lib/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/configuration.rb:1435:in `block in load_spec_files'
	from /var/lib/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/configuration.rb:1433:in `each'
	from /var/lib/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/configuration.rb:1433:in `load_spec_files'
	from /var/lib/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:100:in `setup'
	from /var/lib/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:86:in `run'
	from /var/lib/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:71:in `run'
	from /var/lib/gems/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:45:in `invoke'
	from /var/lib/gems/2.3.0/gems/rspec-core-3.5.4/exe/rspec:4:in `<main>'
```

I added LoadError to the begin/rescue block to be able to run the tests.