### PR TITLE
Support for nested multiple-variable assignments

### DIFF
--- a/lib/puppet-lint/plugins/check_classes.rb
+++ b/lib/puppet-lint/plugins/check_classes.rb
@@ -303,13 +303,23 @@ PuppetLint.new_check(:variable_scope) do
           if token.prev_code_token.type == :VARIABLE
             variables_in_scope << token.prev_code_token.value
           elsif token.prev_code_token.type == :RBRACK
-            temp_token = token.prev_code_token
+            temp_token = token
 
-            until temp_token.type == :LBRACK do
-              if temp_token.type == :VARIABLE
+            brack_depth = 0
+            while temp_token = temp_token.prev_code_token
+              case temp_token.type
+              when :VARIABLE
                 variables_in_scope << temp_token.value
+              when :RBRACK
+                brack_depth += 1
+              when :LBRACK
+                brack_depth -= 1
+                break if brack_depth == 0
+              when :COMMA
+                # ignore
+              else  # unexpected
+                break
               end
-              temp_token = temp_token.prev_code_token
             end
           end
         when :VARIABLE

--- a/spec/puppet-lint/plugins/check_classes/variable_scope_spec.rb
+++ b/spec/puppet-lint/plugins/check_classes/variable_scope_spec.rb
@@ -209,6 +209,18 @@ describe 'variable_scope' do
     end
   end
 
+  context 'nested variable assignment' do
+    let(:code) { "
+      class test {
+        [$foo, [[$bar, $baz], $qux]] = something()
+      }
+    " }
+
+    it 'should not detect any problems' do
+      expect(problems).to have(0).problems
+    end
+  end
+
   context 'function calls inside string interpolation' do
     let(:code) { "
       class test {


### PR DESCRIPTION
This patch is a follow-up for #617 and makes the variable_scope checker support multiple variables assignment for nested arrays, such as:

```pp
[$a, [$b, $c]] = [1, [2, 3]]
```