### PR TITLE
Correctly handle function calls inside string interpolation

### DIFF
--- a/lib/puppet-lint/lexer.rb
+++ b/lib/puppet-lint/lexer.rb
@@ -391,7 +391,7 @@ class PuppetLint
             end
           else
             contents = ss.scan_until(/\}/)[0..-2]
-            if contents.match(/\A(::)?([\w-]+::)*[\w-]+(\[.+?\])*/)
+            if contents.match(/\A(::)?([\w-]+::)*[\w-]+(\[.+?\])*/) && !contents.match(/\A\w+\(/)
               contents = "$#{contents}"
             end
             lexer = PuppetLint::Lexer.new

--- a/spec/puppet-lint/plugins/check_classes/variable_scope_spec.rb
+++ b/spec/puppet-lint/plugins/check_classes/variable_scope_spec.rb
@@ -208,4 +208,34 @@ describe 'variable_scope' do
       expect(problems).to have(0).problems
     end
   end
+
+  context 'function calls inside string interpolation' do
+    let(:code) { "
+      class test {
+        \"${split('1,2,3', ',')}\"  # split is a function
+        \"${lookup('foo::bar')}\"  # lookup is a function
+      }
+    " }
+
+    it 'should not detect any problems' do
+      expect(problems).to have(0).problems
+    end
+  end
+
+  context 'variables in string interpolation' do
+    let(:code) { "
+      class test {
+        \"${foo.split(',')}\"  # foo is a top-scope variable
+        \"${::bar.split(',')}\"
+      }
+    " }
+
+    it 'should only detect one problem' do
+      expect(problems).to have(1).problems
+    end
+
+    it 'should create one warning' do
+      expect(problems).to contain_warning(msg).on_line(3).in_column(11)
+    end
+  end
 end


### PR DESCRIPTION
String interpolations ("${}") can contain a function-call expression, in which case puppet-lint misrecognizes the function name as a top-scope variable.

```
class test {
  "${lookup('foo::bar')}"  # lookup is a function but not a variable
}
```

This patch fixes #635