### PR TITLE
Update the tokeniser to differentiate between unquoted strings and function names

### DIFF
--- a/lib/puppet-lint/lexer.rb
+++ b/lib/puppet-lint/lexer.rb
@@ -89,11 +89,13 @@ class PuppetLint
     # a single regular expression.  Each sub-Array contains 2 elements, the
     # name of the token as a Symbol and a regular expression describing the
     # value of the token.
+    NAME_RE = /\A(((::)?[_a-z0-9][-\w]*)(::[a-z0-9][-\w]*)*)/
     KNOWN_TOKENS = [
       [:TYPE, /\A(Integer|Float|Boolean|Regexp|String|Array|Hash|Resource|Class|Collection|Scalar|Numeric|CatalogEntry|Data|Tuple|Struct|Optional|NotUndef|Variant|Enum|Pattern|Any|Callable|Type|Runtime|Undef|Default)\b/],
       [:CLASSREF, /\A(((::){0,1}[A-Z][-\w]*)+)/],
       [:NUMBER, /\A\b((?:0[xX][0-9A-Fa-f]+|0?\d+(?:\.\d+)?(?:[eE]-?\d+)?))\b/],
-      [:NAME, /\A(((::)?[_a-z0-9][-\w]*)(::[a-z0-9][-\w]*)*)/],
+      [:FUNCTION_NAME, /#{NAME_RE}\(/],
+      [:NAME, NAME_RE],
       [:LBRACK, /\A(\[)/],
       [:RBRACK, /\A(\])/],
       [:LBRACE, /\A(\{)/],

--- a/lib/puppet-lint/plugins/check_resources.rb
+++ b/lib/puppet-lint/plugins/check_resources.rb
@@ -191,7 +191,7 @@ end
 PuppetLint.new_check(:file_mode) do
   MSG = 'mode should be represented as a 4 digit octal value or symbolic mode'
   SYM_RE = "([ugoa]*[-=+][-=+rstwxXugo]*)(,[ugoa]*[-=+][-=+rstwxXugo]*)*"
-  IGNORE_TYPES = Set[:VARIABLE, :UNDEF]
+  IGNORE_TYPES = Set[:VARIABLE, :UNDEF, :FUNCTION_NAME]
   MODE_RE = Regexp.new(/\A([0-7]{4}|#{SYM_RE})\Z/)
 
   def check

--- a/spec/puppet-lint/lexer_spec.rb
+++ b/spec/puppet-lint/lexer_spec.rb
@@ -694,6 +694,14 @@ describe PuppetLint::Lexer do
     end
   end
 
+  context ':FUNCTION_NAME' do
+    it 'should match when a :NAME is followed by a :LPAREN' do
+      token = @lexer.tokenise('my_function(').first
+      expect(token.type).to eq(:FUNCTION_NAME)
+      expect(token.value).to eq('my_function')
+    end
+  end
+
   context ':NUMBER' do
     it 'should match numeric terms' do
       token = @lexer.tokenise('1234567890').first

--- a/spec/puppet-lint/plugins/check_resources/file_mode_spec.rb
+++ b/spec/puppet-lint/plugins/check_resources/file_mode_spec.rb
@@ -131,6 +131,14 @@ describe 'file_mode' do
         expect(problems).to have(0).problems
       end
     end
+
+    context 'mode as a function return value' do
+      let(:code) { "file { 'foo': mode => lookup('bar'), }" }
+
+      it 'should not detect any problems' do
+        expect(problems).to have(0).problems
+      end
+    end
   end
 
   context 'with fix enabled' do
@@ -202,6 +210,18 @@ describe 'file_mode' do
       end
 
       it 'should not modify the original manifest' do
+        expect(manifest).to eq(code)
+      end
+    end
+
+    context 'mode as a function return value' do
+      let(:code) { "file { 'foo': mode => lookup('bar'), }" }
+
+      it 'should not detect any problems' do
+        expect(problems).to have(0).problems
+      end
+
+      it 'should not change the manifest' do
         expect(manifest).to eq(code)
       end
     end

--- a/spec/puppet-lint/plugins/check_resources/unquoted_file_mode_spec.rb
+++ b/spec/puppet-lint/plugins/check_resources/unquoted_file_mode_spec.rb
@@ -27,6 +27,14 @@ describe 'unquoted_file_mode' do
         expect(problems).to contain_warning(msg).on_line(1).in_column(25)
       end
     end
+
+    context 'file mode from a function rvalue' do
+      let(:code) { "file { 'foo': mode => lookup('bar'), }" }
+
+      it 'should not detect any problems' do
+        expect(problems).to have(0).problems
+      end
+    end
   end
 
   context 'with fix enabled' do
@@ -67,6 +75,18 @@ describe 'unquoted_file_mode' do
 
       it 'should single quote the file mode' do
         expect(manifest).to eq("concat { 'foo': mode => '0777' }")
+      end
+    end
+
+    context 'file mode from a function rvalue' do
+      let(:code) { "file { 'foo': mode => lookup('bar'), }" }
+
+      it 'should not detect any problems' do
+        expect(problems).to have(0).problems
+      end
+
+      it 'should not change the manifest' do
+        expect(manifest).to eq(code)
       end
     end
   end


### PR DESCRIPTION
Currently, when the tokeniser hits a function call like `lookup('foo')`, it splits it into a series of tokens like `:NAME`, `:LPAREN`, `:SSTRING`, `:RPAREN`. While this is technically correct, it makes it harder for us to differentiate between an unquoted string and a function name when examining the tokenised file.

My proposed change introduces a new `:FUNCTION_NAME` token type, which is evaluated before `:NAME` token regex and simply checks if this value is followed immediately by an `:LPAREN`.

As a result of this change, we can fix issues like #634 without having add any corner cases to the check logic.

Fixes #634