### PR TITLE
Prevent incomplete node blocks from crashing puppet-lint

### DIFF
--- a/lib/puppet-lint/checkplugin.rb
+++ b/lib/puppet-lint/checkplugin.rb
@@ -35,7 +35,7 @@ class PuppetLint::CheckPlugin
   #
   # Returns an Array of problem Hashes.
   def fix_problems
-    @problems.reject { |problem| problem[:kind] == :ignored }.each do |problem|
+    @problems.reject { |problem| problem[:kind] == :ignored || problem[:check] == :syntax }.each do |problem|
       if self.respond_to?(:fix)
         begin
           fix(problem)

--- a/lib/puppet-lint/checkplugin.rb
+++ b/lib/puppet-lint/checkplugin.rb
@@ -21,7 +21,7 @@ class PuppetLint::CheckPlugin
     check
 
     @problems.each do |problem|
-      if PuppetLint::Data.ignore_overrides[problem[:check]].has_key?(problem[:line])
+      if problem[:check] != :syntax && PuppetLint::Data.ignore_overrides[problem[:check]].has_key?(problem[:line])
         problem[:kind] = :ignored
         problem[:reason] = PuppetLint::Data.ignore_overrides[problem[:check]][problem[:line]]
         next

--- a/lib/puppet-lint/plugins/check_nodes.rb
+++ b/lib/puppet-lint/plugins/check_nodes.rb
@@ -8,6 +8,16 @@ PuppetLint.new_check(:unquoted_node_name) do
     node_tokens.each do |node|
       node_token_idx = tokens.index(node)
       node_lbrace_tok = tokens[node_token_idx..-1].find { |token| token.type == :LBRACE }
+      if node_lbrace_tok.nil?
+        notify :error, {
+          :check    => :syntax,
+          :message  => 'Syntax error (try running `puppet parser validate <file>`)',
+          :line     => node.line,
+          :column   => node.column,
+        }
+        next
+      end
+
       node_lbrace_idx = tokens.index(node_lbrace_tok)
 
       tokens[node_token_idx..node_lbrace_idx].select { |token|

--- a/spec/puppet-lint/plugins/check_nodes/unquoted_node_name_spec.rb
+++ b/spec/puppet-lint/plugins/check_nodes/unquoted_node_name_spec.rb
@@ -79,6 +79,18 @@ describe 'unquoted_node_name' do
         expect(problems).to contain_warning(msg).on_line(1).in_column(19)
       end
     end
+
+    context 'incomplete node block' do
+      let(:code) { 'node foo' }
+
+      it 'should detect a problem' do
+        expect(problems).to have(1).problem
+      end
+
+      it 'should create 1 error' do
+        expect(problems).to contain_error('Syntax error (try running `puppet parser validate <file>`)').on_line(1).in_column(1)
+      end
+    end
   end
 
   context 'with fix enabled' do


### PR DESCRIPTION
While the ideal solution is to make use of the syntax validation built into Puppet and will be coming in a future puppet-lint release, this is a temporary stop gap to prevent puppet-lint from crashing and throwing a nasty stack trace to the user when it encounters a node block without the requisite braces.

Fixes #582