### PR TITLE
Warn when control comment blocks are not properly terminated

### DIFF
--- a/lib/puppet-lint/data.rb
+++ b/lib/puppet-lint/data.rb
@@ -497,7 +497,6 @@ class PuppetLint::Data
 
           if command == 'ignore'
             check = split_control[2].to_sym
-
             if token.prev_token && !Set[:NEWLINE, :INDENT].include?(token.prev_token.type)
               # control comment at the end of the line, override applies to
               # a single line only
@@ -523,6 +522,10 @@ class PuppetLint::Data
           end
         end
         stack << stack_add unless stack_add.empty?
+      end
+
+      stack.each do |control|
+        puts "WARNING: lint:ignore:#{control[0][2]} comment on line #{control[0][0]} with no closing lint:endignore comment"
       end
     end
   end

--- a/spec/fixtures/test/manifests/unterminated_control_comment.pp
+++ b/spec/fixtures/test/manifests/unterminated_control_comment.pp
@@ -1,0 +1,5 @@
+jenkins::cli::exec { "create-jenkins-credentials-${title}":
+  # lint:ignore:140chars
+  unless  => "for i in \$(seq 1 ${::jenkins::cli_tries}); do \$HELPER_CMD credential_info ${title} && break || sleep ${::jenkins::cli_try_sleep}; done | grep ${title}",
+  # lint:end
+}

--- a/spec/puppet-lint/bin_spec.rb
+++ b/spec/puppet-lint/bin_spec.rb
@@ -336,4 +336,12 @@ describe PuppetLint::Bin do
     its(:exitstatus) { is_expected.to eq(0) }
     its(:stdout) { is_expected.to match(/WARNING: lint:endignore comment with no opening lint:ignore:<check> comment found on line 1/) }
   end
+
+  context 'when a lint:ignore control comment block is not terminated properly' do
+    let(:args) { [
+      'spec/fixtures/test/manifests/unterminated_control_comment.pp',
+    ] }
+
+    its(:stdout) { is_expected.to match(/WARNING: lint:ignore:140chars comment on line 2 with no closing lint:endignore comment/) }
+  end
 end


### PR DESCRIPTION
For cases like #622 where an incorrect comment was used to close out an ignored block of code; rather than silently failing to set up the ignore, print a warning so that the user knows that its not working.

Fixes #622