### PR TITLE
(SDK-115) Enable appveyor testing

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,37 @@
+build: off
+
+branches:
+  only:
+    - master
+
+# ruby versions under test
+environment:
+  matrix:
+    - RUBY_VERSION: 187
+    - RUBY_VERSION: 193
+    - RUBY_VERSION: 200
+    - RUBY_VERSION: 219
+    - RUBY_VERSION: 231
+    - RUBY_VERSION: 240
+
+matrix:
+  allow_failures:
+    - RUBY_VERSION: 187
+
+install:
+  - SET PATH=C:\Ruby%RUBY_VERSION%\bin;%PATH%
+  - SET LOG_SPEC_ORDER=true
+  - bundle install --jobs 4 --retry 2 --without development
+
+before_test:
+  - type Gemfile.lock
+  - ruby -v
+  - gem -v
+  - bundle -v
+
+test_script:
+  - bundle exec rake test
+
+notifications:
+  email:
+    - tim@bombasticmonkey.com

--- a/spec/puppet-lint/bin_spec.rb
+++ b/spec/puppet-lint/bin_spec.rb
@@ -209,7 +209,7 @@ describe PuppetLint::Bin do
 
       its(:exitstatus) { is_expected.to eq(1) }
       its(:stdout) {
-        is_expected.to match(%r{^/.+/spec/fixtures/test/manifests/fail\.pp$})
+        is_expected.to match(%r{^(/|[A-Za-z]\:).+/spec/fixtures/test/manifests/fail\.pp$})
       }
     end
 


### PR DESCRIPTION
Add appveyor.yml that tests on the same rubies as travis.
Small fix to one test to allow a full path to start with a drive letter as well as /

You can see these tests passing here:
https://ci.appveyor.com/project/james-stocks/puppet-lint/build/1.0.5

I do not have permissions to enable appveyor on this repo.