### PR TITLE
Plugins: Improve code readability

### DIFF
--- a/lib/puppet-lint/plugins/check_classes/autoloader_layout.rb
+++ b/lib/puppet-lint/plugins/check_classes/autoloader_layout.rb
@@ -5,28 +5,28 @@
 # https://docs.puppet.com/guides/style_guide.html#separate-files
 PuppetLint.new_check(:autoloader_layout) do
   def check
-    unless fullpath.nil? || fullpath == ''
-      (class_indexes + defined_type_indexes).each do |class_idx|
-        title_token = class_idx[:name_token]
-        split_title = title_token.value.split('::')
-        mod = split_title.first
-        if split_title.length > 1
-          expected_path = "/#{mod}/manifests/#{split_title[1..-1].join('/')}.pp"
-        else
-          expected_path = "/#{title_token.value}/manifests/init.pp"
-        end
+    return if fullpath.nil? || fullpath == ''
 
-        if PuppetLint.configuration.relative
-          expected_path = expected_path.gsub(/^\//,'').split('/')[1..-1].join('/')
-        end
+    (class_indexes + defined_type_indexes).each do |class_idx|
+      title_token = class_idx[:name_token]
+      split_title = title_token.value.split('::')
+      mod = split_title.first
+      if split_title.length > 1
+        expected_path = "/#{mod}/manifests/#{split_title[1..-1].join('/')}.pp"
+      else
+        expected_path = "/#{title_token.value}/manifests/init.pp"
+      end
 
-        unless fullpath.end_with? expected_path
-          notify :error, {
-            :message => "#{title_token.value} not in autoload module layout",
-            :line    => title_token.line,
-            :column  => title_token.column,
-          }
-        end
+      if PuppetLint.configuration.relative
+        expected_path = expected_path.gsub(/^\//,'').split('/')[1..-1].join('/')
+      end
+
+      unless fullpath.end_with? expected_path
+        notify :error, {
+          :message => "#{title_token.value} not in autoload module layout",
+          :line    => title_token.line,
+          :column  => title_token.column,
+        }
       end
     end
   end

--- a/lib/puppet-lint/plugins/check_classes/class_inherits_from_params_class.rb
+++ b/lib/puppet-lint/plugins/check_classes/class_inherits_from_params_class.rb
@@ -5,15 +5,13 @@
 PuppetLint.new_check(:class_inherits_from_params_class) do
   def check
     class_indexes.each do |class_idx|
-      unless class_idx[:inherited_token].nil?
-        if class_idx[:inherited_token].value.end_with? '::params'
-          notify :warning, {
-            :message => 'class inheriting from params class',
-            :line    => class_idx[:inherited_token].line,
-            :column  => class_idx[:inherited_token].column,
-          }
-        end
-      end
+      next unless class_idx[:inherited_token] && class_idx[:inherited_token].value.end_with?('::params')
+
+      notify :warning, {
+        :message => 'class inheriting from params class',
+        :line    => class_idx[:inherited_token].line,
+        :column  => class_idx[:inherited_token].column,
+      }
     end
   end
 end

--- a/lib/puppet-lint/plugins/check_classes/inherits_across_namespaces.rb
+++ b/lib/puppet-lint/plugins/check_classes/inherits_across_namespaces.rb
@@ -5,17 +5,17 @@
 PuppetLint.new_check(:inherits_across_namespaces) do
   def check
     class_indexes.each do |class_idx|
-      unless class_idx[:inherited_token].nil?
-        inherited_module_name = class_idx[:inherited_token].value.split('::').reject { |r| r.empty? }.first
-        class_module_name = class_idx[:name_token].value.split('::').reject { |r| r.empty? }.first
+      next if class_idx[:inherited_token].nil?
 
-        unless class_module_name == inherited_module_name
-          notify :warning, {
-            :message => "class inherits across module namespaces",
-            :line    => class_idx[:inherited_token].line,
-            :column  => class_idx[:inherited_token].column,
-          }
-        end
+      inherited_module_name = class_idx[:inherited_token].value.split('::').reject(&:empty?).first
+      class_module_name = class_idx[:name_token].value.split('::').reject(&:empty?).first
+
+      unless class_module_name == inherited_module_name
+        notify :warning, {
+          :message => "class inherits across module namespaces",
+          :line    => class_idx[:inherited_token].line,
+          :column  => class_idx[:inherited_token].column,
+        }
       end
     end
   end

--- a/lib/puppet-lint/plugins/check_classes/names_containing_dash.rb
+++ b/lib/puppet-lint/plugins/check_classes/names_containing_dash.rb
@@ -5,19 +5,19 @@
 PuppetLint.new_check(:names_containing_dash) do
   def check
     (class_indexes + defined_type_indexes).each do |class_idx|
-      if class_idx[:name_token].value.include? '-'
-        if class_idx[:type] == :CLASS
-          obj_type = 'class'
-        else
-          obj_type = 'defined type'
-        end
+      next unless class_idx[:name_token].value.include? '-'
 
-        notify :error, {
-          :message => "#{obj_type} name containing a dash",
-          :line    => class_idx[:name_token].line,
-          :column  => class_idx[:name_token].column,
-        }
+      if class_idx[:type] == :CLASS
+        obj_type = 'class'
+      else
+        obj_type = 'defined type'
       end
+
+      notify :error, {
+        :message => "#{obj_type} name containing a dash",
+        :line    => class_idx[:name_token].line,
+        :column  => class_idx[:name_token].column,
+      }
     end
   end
 end

--- a/lib/puppet-lint/plugins/check_conditionals/selector_inside_resource.rb
+++ b/lib/puppet-lint/plugins/check_conditionals/selector_inside_resource.rb
@@ -6,18 +6,15 @@ PuppetLint.new_check(:selector_inside_resource) do
   def check
     resource_indexes.each do |resource|
       resource[:tokens].each do |token|
-        if token.type == :FARROW
-          if token.next_code_token.type == :VARIABLE
-            unless token.next_code_token.next_code_token.nil?
-              if token.next_code_token.next_code_token.type == :QMARK
-                notify :warning, {
-                  :message => 'selector inside resource block',
-                  :line    => token.line,
-                  :column  => token.column,
-                }
-              end
-            end
-          end
+        next unless token.type == :FARROW && token.next_code_token.type == :VARIABLE
+        next if token.next_code_token.next_code_token.nil?
+
+        if token.next_code_token.next_code_token.type == :QMARK
+          notify :warning, {
+            :message => 'selector inside resource block',
+            :line    => token.line,
+            :column  => token.column,
+          }
         end
       end
     end

--- a/lib/puppet-lint/plugins/check_documentation/documentation.rb
+++ b/lib/puppet-lint/plugins/check_documentation/documentation.rb
@@ -9,12 +9,9 @@ PuppetLint.new_check(:documentation) do
 
   def check
     (class_indexes + defined_type_indexes).each do |item_idx|
-      prev_token = item_idx[:tokens].first.prev_token
-      while (!prev_token.nil?) && WHITESPACE_TOKENS.include?(prev_token.type)
-        prev_token = prev_token.prev_token
-      end
+      comment_token = find_comment_token(item_idx[:tokens].first)
 
-      unless (!prev_token.nil?) && COMMENT_TOKENS.include?(prev_token.type)
+      if comment_token.nil?
         first_token = item_idx[:tokens].first
         if first_token.type == :CLASS
           type = 'class'
@@ -29,5 +26,16 @@ PuppetLint.new_check(:documentation) do
         }
       end
     end
+  end
+
+  def find_comment_token(start_token)
+    prev_token = start_token.prev_token
+    while (!prev_token.nil?) && WHITESPACE_TOKENS.include?(prev_token.type)
+      prev_token = prev_token.prev_token
+    end
+
+    return if prev_token.nil?
+
+    prev_token if COMMENT_TOKENS.include?(prev_token.type)
   end
 end

--- a/lib/puppet-lint/plugins/check_nodes/unquoted_node_name.rb
+++ b/lib/puppet-lint/plugins/check_nodes/unquoted_node_name.rb
@@ -21,16 +21,14 @@ PuppetLint.new_check(:unquoted_node_name) do
       node_lbrace_idx = tokens.index(node_lbrace_tok)
 
       tokens[node_token_idx..node_lbrace_idx].select { |token|
-        token.type == :NAME
+        token.type == :NAME && token.value != 'default'
       }.each do |token|
-        unless token.value == 'default'
-          notify :warning, {
-            :message => 'unquoted node name found',
-            :line    => token.line,
-            :column  => token.column,
-            :token   => token,
-          }
-        end
+        notify :warning, {
+          :message => 'unquoted node name found',
+          :line    => token.line,
+          :column  => token.column,
+          :token   => token,
+        }
       end
     end
   end

--- a/spec/puppet-lint/plugins/check_classes/names_containing_dash_spec.rb
+++ b/spec/puppet-lint/plugins/check_classes/names_containing_dash_spec.rb
@@ -42,4 +42,16 @@ describe 'names_containing_dash' do
       expect(problems).to contain_error(class_msg).on_line(1).in_column(7)
     end
   end
+
+  context 'multiple classes' do
+    let(:code) do '
+       class foo::bar_foo { }
+       class foo::baz-foo { }
+      '
+    end
+
+    it 'should create an error' do
+      expect(problems).to contain_error(class_msg).on_line(3).in_column(14)
+    end
+  end
 end


### PR DESCRIPTION
Mostly applied early returns to lower the nesting level.
In some cases extracted helper methods to make the code more obvious.