### PR TITLE
Fix showing of a failure

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -75,8 +75,9 @@ module RSpec
 
           messages << check_attr(:kind, 'would be of kind')
           messages << check_attr(:message, 'would have the message')
-          messages << check_attr(:linenumber, 'would be on line')
+          messages << check_attr(:line, 'would be on line')
           messages << check_attr(:column, 'would start on column')
+          messages << check_attr(:reason, 'would have the reason')
 
           messages.compact.join("\n  ")
         else


### PR DESCRIPTION
When the expected problem is not at the same line number as the actual one, the message displayed is:
`expected that the problem` 
with no further info.

Same happens if `reason` is not the expected one, when `with_reason` is used