### PR TITLE
Allow regexps to used as function arguments

### DIFF
--- a/lib/puppet-lint/lexer.rb
+++ b/lib/puppet-lint/lexer.rb
@@ -83,6 +83,7 @@ class PuppetLint
       :LBRACK  => true,
       :IF      => true,
       :ELSIF   => true,
+      :LPAREN  => true,
     }
 
     # Internal: An Array of Arrays containing tokens that can be described by

--- a/spec/puppet-lint/lexer_spec.rb
+++ b/spec/puppet-lint/lexer_spec.rb
@@ -871,6 +871,12 @@ describe PuppetLint::Lexer do
       expect(tokens[2].type).to eq(:REGEX)
       expect(tokens[14].type).to eq(:REGEX)
     end
+
+    it 'should properly parse when a regex is provided as a function argument' do
+      tokens = @lexer.tokenise('$somevar = $other_var.match(/([\w\.]+(:\d+)?(\/\w+)?)(:(\w+))?/)')
+      expect(tokens[8].type).to eq(:REGEX)
+      expect(tokens[8].value).to eq('([\w\.]+(:\d+)?(\/\w+)?)(:(\w+))?')
+    end
   end
 
   context ':STRING' do


### PR DESCRIPTION
As exposed in #645, the tokeniser wasn't properly handling regexps when they were used as the first argument in a function (second, third, ... nth worked fine, just not first). When this case was encountered, the regexp would be split into all its component tokens causing very unexpected results (especially if the regexp contained a colon).

Fixes #645