### PR TITLE
Clear expected parameter column after processing each block when checking arrow alignment

### DIFF
--- a/lib/puppet-lint/plugins/check_whitespace.rb
+++ b/lib/puppet-lint/plugins/check_whitespace.rb
@@ -125,8 +125,8 @@ PuppetLint.new_check(:arrow_alignment) do
 
   def check
     resource_indexes.each do |res_idx|
-      indent_depth = [0]
-      indent_depth_idx = 0
+      arrow_column = [0]
+      level_idx = 0
       level_tokens = []
       param_column = [nil]
       resource_tokens = res_idx[:tokens]
@@ -143,7 +143,7 @@ PuppetLint.new_check(:arrow_alignment) do
 
       resource_tokens.each_with_index do |token, idx|
         if token.type == :FARROW
-          (level_tokens[indent_depth_idx] ||= []) << token
+          (level_tokens[level_idx] ||= []) << token
           param_token = token.prev_code_token
 
           if param_token.type == :DQPOST
@@ -158,44 +158,44 @@ PuppetLint.new_check(:arrow_alignment) do
             param_length = param_token.to_manifest.length
           end
 
-          if param_column[indent_depth_idx].nil?
+          if param_column[level_idx].nil?
             if param_token.type == :DQPOST
-              param_column[indent_depth_idx] = iter_token.column
+              param_column[level_idx] = iter_token.column
             else
-              param_column[indent_depth_idx] = param_token.column
+              param_column[level_idx] = param_token.column
             end
           end
 
-          indent_length = param_column[indent_depth_idx] + param_length + 1
+          this_arrow_column = param_column[level_idx] + param_length + 1
 
-          if indent_depth[indent_depth_idx] < indent_length
-            indent_depth[indent_depth_idx] = indent_length
+          if arrow_column[level_idx] < this_arrow_column
+            arrow_column[level_idx] = this_arrow_column
           end
 
         elsif token.type == :LBRACE
-          indent_depth_idx += 1
-          indent_depth << 0
-          level_tokens[indent_depth_idx] ||= []
+          level_idx += 1
+          arrow_column << 0
+          level_tokens[level_idx] ||= []
           param_column << nil
         elsif token.type == :RBRACE || token.type == :SEMIC
-          level_tokens[indent_depth_idx].each do |arrow_tok|
-            unless arrow_tok.column == indent_depth[indent_depth_idx] || level_tokens[indent_depth_idx].size == 1
-              arrows_on_line = level_tokens[indent_depth_idx].select { |t| t.line == arrow_tok.line }
+          level_tokens[level_idx].each do |arrow_tok|
+            unless arrow_tok.column == arrow_column[level_idx] || level_tokens[level_idx].size == 1
+              arrows_on_line = level_tokens[level_idx].select { |t| t.line == arrow_tok.line }
               notify :warning, {
-                :message        => "indentation of => is not properly aligned (expected in column #{indent_depth[indent_depth_idx]}, but found it in column #{arrow_tok.column})",
+                :message        => "indentation of => is not properly aligned (expected in column #{arrow_column[level_idx]}, but found it in column #{arrow_tok.column})",
                 :line           => arrow_tok.line,
                 :column         => arrow_tok.column,
                 :token          => arrow_tok,
-                :indent_depth   => indent_depth[indent_depth_idx],
+                :arrow_column   => arrow_column[level_idx],
                 :newline        => !(arrows_on_line.index(arrow_tok) == 0),
-                :newline_indent => param_column[indent_depth_idx] - 1,
+                :newline_indent => param_column[level_idx] - 1,
               }
             end
           end
-          indent_depth[indent_depth_idx] = 0
-          level_tokens[indent_depth_idx].clear
-          param_column[indent_depth_idx] = nil
-          indent_depth_idx -= 1
+          arrow_column[level_idx] = 0
+          level_tokens[level_idx].clear
+          param_column[level_idx] = nil
+          level_idx -= 1
         end
       end
     end
@@ -214,7 +214,7 @@ PuppetLint.new_check(:arrow_alignment) do
     else
       param_length = param_token.to_manifest.length
     end
-    new_ws_len = (problem[:indent_depth] - (problem[:newline_indent] + param_length + 1))
+    new_ws_len = (problem[:arrow_column] - (problem[:newline_indent] + param_length + 1))
     new_ws = ' ' * new_ws_len
     if problem[:newline]
       index = tokens.index(problem[:token].prev_code_token.prev_token)

--- a/lib/puppet-lint/plugins/check_whitespace.rb
+++ b/lib/puppet-lint/plugins/check_whitespace.rb
@@ -139,7 +139,7 @@ PuppetLint.new_check(:arrow_alignment) do
       last_arrow = resource_tokens.rindex { |r| r.type == :FARROW }
       next if first_arrow.nil?
       next if last_arrow.nil?
-      next unless resource_tokens[first_arrow..last_arrow].any? { |r| r.type == :NEWLINE }
+      next if resource_tokens[first_arrow].line == resource_tokens[last_arrow].line
 
       resource_tokens.each_with_index do |token, idx|
         if token.type == :FARROW
@@ -194,6 +194,7 @@ PuppetLint.new_check(:arrow_alignment) do
           end
           indent_depth[indent_depth_idx] = 0
           level_tokens[indent_depth_idx].clear
+          param_column[indent_depth_idx] = nil
           indent_depth_idx -= 1
         end
       end

--- a/spec/puppet-lint/plugins/check_whitespace/arrow_alignment_spec.rb
+++ b/spec/puppet-lint/plugins/check_whitespace/arrow_alignment_spec.rb
@@ -402,6 +402,28 @@ describe 'arrow_alignment' do
         expect(problems).to contain_warning(sprintf(msg,23,19)).on_line(6).in_column(19)
       end
     end
+
+    context 'complex data structure with different indentation levels at the same depth' do
+      let(:code) { "
+        class { 'some_class':
+          config_hash => {
+            'a_hash'   => {
+              'foo' => 'bar',
+            },
+            'an_array' => [
+              {
+                foo => 'bar',
+                bar => 'baz',
+              },
+            ],
+          },
+        }
+      " }
+
+      it 'should not detect any problems' do
+        expect(problems).to have(0).problems
+      end
+    end
   end
 
   context 'with fix enabled' do
@@ -669,6 +691,52 @@ describe 'arrow_alignment' do
       it 'should fix 2 problems' do
         expect(problems).to contain_fixed(sprintf(msg,23,15)).on_line(4).in_column(15)
         expect(problems).to contain_fixed(sprintf(msg,23,19)).on_line(6).in_column(19)
+      end
+
+      it 'should align the hash rockets' do
+        expect(manifest).to eq(fixed)
+      end
+    end
+
+    context 'complex data structure with different indentation levels at the same depth' do
+      let(:code) { "
+        class { 'some_class':
+          config_hash => {
+            'a_hash'   => {
+              'foo' => 'bar',
+            },
+            'an_array' => [
+              {
+                foo => 'bar',
+                bar  => 'baz',
+              },
+            ],
+          },
+        }
+      " }
+
+      let(:fixed) { "
+        class { 'some_class':
+          config_hash => {
+            'a_hash'   => {
+              'foo' => 'bar',
+            },
+            'an_array' => [
+              {
+                foo => 'bar',
+                bar => 'baz',
+              },
+            ],
+          },
+        }
+      " }
+
+      it 'should detect 1 problem' do
+        expect(problems).to have(1).problems
+      end
+
+      it 'should fix 1 problem' do
+        expect(problems).to contain_fixed(sprintf(msg, 21, 22)).on_line(10).in_column(22)
       end
 
       it 'should align the hash rockets' do


### PR DESCRIPTION
When calculating the expected column for the `=>`s to be placed, we split the tokens into a stack of `{ }` delimited blocks. Previously we assumed that blocks of the same depth would have same amount of indentation, e.g.

```
# start at depth 0
class foo { # move to depth 1
  $foo = { # move to depth 2
    bar => baz,
  } # move to depth 1
  $something = { # move to depth 2
    this => value,
  } # move to depth 1
} # move to depth 0
```

Unfortunately for this assumption, with more complex data structures you can easily have identical depths with different indentation levels, e.g.

```
$my_hash = {
  value_1 => {
    foo => bar, # depth 2
  },
  value_2 => [
    {
      foo => bar, # also depth 2 but indented by two additional spaces
    }
  ]
}
```

This PR changes the logic of the check slightly so that we now clear the expected parameter column for each depth as we finish processing that block, allowing it to be recalculated when processing another block at the same depth. Also, the names of the variables that stored the expected arrow column number and the depth counter have been updated to something that more accurately represents their purpose.

Fixes #654