### PR TITLE
Restrict appveyor testing to Ruby versions that appveyor supports

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,16 +7,11 @@ branches:
 # ruby versions under test
 environment:
   matrix:
-    - RUBY_VERSION: 187
     - RUBY_VERSION: 193
     - RUBY_VERSION: 200
-    - RUBY_VERSION: 219
-    - RUBY_VERSION: 231
-    - RUBY_VERSION: 240
-
-matrix:
-  allow_failures:
-    - RUBY_VERSION: 187
+    - RUBY_VERSION: 21
+    - RUBY_VERSION: 22
+    - RUBY_VERSION: 23-x64
 
 install:
   - SET PATH=C:\Ruby%RUBY_VERSION%\bin;%PATH%


### PR DESCRIPTION
The previous appveyor.yml copied the Ruby versions that travis tests on.
However, appveyor only supports a limited number of ruby versions ( https://www.appveyor.com/docs/build-environment/ )

This wasn't immediately obvious because appveyor defaults to Ruby 1.9.3 then passes tests rather than failing.

This commit changes to only Ruby versions provided by appveyor.