### PR TITLE
Fix ensure_first_param fix method to retrieve the full value of the ensure parameter

### DIFF
--- a/lib/puppet-lint/lexer/token.rb
+++ b/lib/puppet-lint/lexer/token.rb
@@ -99,7 +99,7 @@ class PuppetLint
 
       # Public: Search from this token to find the next token of a given type.
       #
-      # type - A Symbol type of the token to find
+      # type - A Symbol type of the token to find, or an Array of Symbols.
       # opts - An optional Hash
       #   :value       - A token value to search for in addition to type
       #   :skip_blocks - A Boolean to specify whether { } blocks should be
@@ -113,7 +113,7 @@ class PuppetLint
 
       # Public: Search from this token to find the previous token of a given type.
       #
-      # type - A Symbol type of the token to find
+      # type - A Symbol type of the token to find, or an Array of Symbols.
       # opts - An optional Hash
       #   :value       - A token value to search for in addition to type
       #   :skip_blocks - A Boolean to specify whether { } blocks should be
@@ -129,7 +129,7 @@ class PuppetLint
       # in a given direction.
       #
       # direction - A Symbol direction to search (:next or :prev).
-      # type      - A Symbol type of the token to find
+      # type      - A Symbol type of the token to find, or an Array of Symbols.
       # opts      - An optional Hash
       #   :value       - A token value to search for in addition to type
       #   :skip_blocks - A Boolean to specify whether { } blocks should be

--- a/lib/puppet-lint/lexer/token.rb
+++ b/lib/puppet-lint/lexer/token.rb
@@ -96,6 +96,38 @@ class PuppetLint
           @value
         end
       end
+
+      # Public: Search from this token to find the next token of a given type.
+      #
+      # type - A Symbol type of the token to find
+      # opts - An optional Hash
+      #   :value       - A token value to search for in addition to type
+      #   :skip_blocks - A Boolean to specify whether { } blocks should be
+      #                  skipped over (defaults to true).
+      #
+      # Returns a PuppetLint::Lexer::Token object if a matching token could be
+      # found, otherwise nil.
+      def next_token_of(type, opts = {})
+        opts[:skip_blocks] ||= true
+        to_find = Array[*type]
+
+        token_iter = next_token
+        while !token_iter.nil?
+          if to_find.include? token_iter.type
+            if opts[:value]
+              return token_iter if token_iter.value == opts[:value]
+            else
+              return token_iter
+            end
+          end
+
+          if opts[:skip_blocks] && token_iter.type == :LBRACE
+            token_iter = token_iter.next_token_of(:RBRACE, opts)
+          end
+          token_iter = token_iter.next_token
+        end
+        nil
+      end
     end
   end
 end


### PR DESCRIPTION
Previously, the fix method for the `ensure_first_param` check looked for the first `:COMMA` or `:SEMIC` token after the ensure param name to find the end of the parameter value, which works for most cases, but not when the value of the ensure parameter is a selector.

This PR fixes this behaviour by adding a `next_token_of` method to `PuppetLint::Lexer::Token` that encapsulates the logic of finding the next token of a certain type (and optionally value) with smarts to skip over blocks. Similarly, a `prev_token_of` method also now exists. These two methods resolve #660 and we can later refactor a lot of the puppet-lint codebase to use these methods and simplify the code a lot.

Fixes #659 & #660