### PR TITLE
Don't silently remove unnecessary $ from enclosed variables

### DIFF
--- a/lib/puppet-lint/lexer/token.rb
+++ b/lib/puppet-lint/lexer/token.rb
@@ -79,7 +79,11 @@ class PuppetLint
         when :VARIABLE
           enclose_token_types = Set[:DQPRE, :DQMID, :HEREDOC_PRE, :HEREDOC_MID].freeze
           if !@prev_code_token.nil? && enclose_token_types.include?(@prev_code_token.type)
-            "${#{@value}}"
+            if @raw.nil?
+              "${#{@value}}"
+            else
+              "${#{@raw}}"
+            end
           else
             "$#{@value}"
           end


### PR DESCRIPTION
Puppet's language allows you to use an unnecessary `$` in enclosed variables e.g. `${$foo}`. At the moment due to the way our lexer works, this extra `$` is removed when run in fix mode without displaying a warning to the user (as reported in #655).

This PR is a bit unusual in that it removes the code that automatically fixes this issue. I've chosen to do this because the style guide doesn't currently mention this case, so I'm going to open issues to update the style guide and also add this as a separate check to puppet-lint.

Fixes #655 