### PR TITLE
Support double quoted strings inside interpolated values in double quoted strings

### DIFF
--- a/lib/puppet-lint/lexer.rb
+++ b/lib/puppet-lint/lexer.rb
@@ -203,7 +203,7 @@ class PuppetLint
             tokens << new_token(:SSTRING, str_content[0..-2])
 
           elsif chunk.match(/\A"/)
-            str_contents = StringScanner.new(code[i+1..-1]).scan_until(/(\A|[^\\])(\\\\)*"/m)
+            str_contents = slurp_string(code[i+1..-1])
             _ = code[0..i].split("\n")
             interpolate_string(str_contents, _.count, _.last.length)
             length = str_contents.size + 1
@@ -287,6 +287,18 @@ class PuppetLint
       end
 
       tokens
+    end
+
+
+    def slurp_string(string)
+      dq_str_regexp = /(\$\{|(\A|[^\\])(\\\\)*")/m
+      scanner = StringScanner.new(string)
+      contents = scanner.scan_until(dq_str_regexp)
+      until scanner.matched.end_with?('"')
+        contents += scanner.scan_until(/\}/m)
+        contents += scanner.scan_until(dq_str_regexp)
+      end
+      contents
     end
 
     # Internal: Given the tokens already processed, determine if the next token

--- a/spec/puppet-lint/lexer_spec.rb
+++ b/spec/puppet-lint/lexer_spec.rb
@@ -1209,5 +1209,32 @@ describe PuppetLint::Lexer do
       expect(token.type).to eq(:STRING)
       expect(token.value).to eq("\n")
     end
+
+    it 'should handle interpolated values that contain double quotes' do
+      manifest = %Q{"export bar=\\"${join(hiera('test'), "," )}\\""}
+
+      tokens = @lexer.tokenise(manifest)
+      expect(tokens[0].type).to eq(:DQPRE)
+      expect(tokens[0].value).to eq('export bar=\"')
+      expect(tokens[1].type).to eq(:FUNCTION_NAME)
+      expect(tokens[1].value).to eq('join')
+      expect(tokens[2].type).to eq(:LPAREN)
+      expect(tokens[3].type).to eq(:FUNCTION_NAME)
+      expect(tokens[3].value).to eq('hiera')
+      expect(tokens[4].type).to eq(:LPAREN)
+      expect(tokens[5].type).to eq(:SSTRING)
+      expect(tokens[5].value).to eq('test')
+      expect(tokens[6].type).to eq(:RPAREN)
+      expect(tokens[7].type).to eq(:COMMA)
+      expect(tokens[8].type).to eq(:WHITESPACE)
+      expect(tokens[8].value).to eq(' ')
+      expect(tokens[9].type).to eq(:STRING)
+      expect(tokens[9].value).to eq(',')
+      expect(tokens[10].type).to eq(:WHITESPACE)
+      expect(tokens[10].value).to eq(' ')
+      expect(tokens[11].type).to eq(:RPAREN)
+      expect(tokens[12].type).to eq(:DQPOST)
+      expect(tokens[12].value).to eq('\"')
+    end
   end
 end


### PR DESCRIPTION
Somewhat confusing title, but basically adds support for doing things like `"foo ${join($array, "\n")}"`. Previously, when we detected a `"` character, we would scan up to the next `"` and then pass everything between off to `PuppetLint::Lexer#interpolate_string`. As the Puppet language now supports doing things like the afore mentioned example, this logic needed to change. Through the new `slurp_string` method, we are now a bit more clever about how we scan for the end of the string. If we detect a `${`, we stop looking for `"` until we've found the `}` to close out the interpolated value.

Fixes #516