### PR TITLE
Fix for arrow_alignment bugs in #506

### DIFF
--- a/lib/puppet-lint/plugins/check_whitespace.rb
+++ b/lib/puppet-lint/plugins/check_whitespace.rb
@@ -178,18 +178,20 @@ PuppetLint.new_check(:arrow_alignment) do
           level_tokens[level_idx] ||= []
           param_column << nil
         elsif token.type == :RBRACE || token.type == :SEMIC
-          level_tokens[level_idx].each do |arrow_tok|
-            unless arrow_tok.column == arrow_column[level_idx] || level_tokens[level_idx].size == 1
-              arrows_on_line = level_tokens[level_idx].select { |t| t.line == arrow_tok.line }
-              notify :warning, {
-                :message        => "indentation of => is not properly aligned (expected in column #{arrow_column[level_idx]}, but found it in column #{arrow_tok.column})",
-                :line           => arrow_tok.line,
-                :column         => arrow_tok.column,
-                :token          => arrow_tok,
-                :arrow_column   => arrow_column[level_idx],
-                :newline        => !(arrows_on_line.index(arrow_tok) == 0),
-                :newline_indent => param_column[level_idx] - 1,
-              }
+          if level_tokens[level_idx].map(&:line).uniq.length > 1
+            level_tokens[level_idx].each do |arrow_tok|
+              unless arrow_tok.column == arrow_column[level_idx] || level_tokens[level_idx].size == 1
+                arrows_on_line = level_tokens[level_idx].select { |t| t.line == arrow_tok.line }
+                notify :warning, {
+                  :message        => "indentation of => is not properly aligned (expected in column #{arrow_column[level_idx]}, but found it in column #{arrow_tok.column})",
+                  :line           => arrow_tok.line,
+                  :column         => arrow_tok.column,
+                  :token          => arrow_tok,
+                  :arrow_column   => arrow_column[level_idx],
+                  :newline        => !(arrows_on_line.index(arrow_tok) == 0),
+                  :newline_indent => param_column[level_idx] - 1,
+                }
+              end
             end
           end
           arrow_column[level_idx] = 0

--- a/lib/puppet-lint/plugins/check_whitespace.rb
+++ b/lib/puppet-lint/plugins/check_whitespace.rb
@@ -217,7 +217,7 @@ PuppetLint.new_check(:arrow_alignment) do
 
     end_param_idx = tokens.index(problem[:token].prev_code_token)
     start_param_idx = tokens.index(problem[:token].prev_token_of([:INDENT, :NEWLINE])) + 1
-    param_length = tokens[start_param_idx..end_param_idx].map { |r| r.to_manifest.length }.sum
+    param_length = tokens[start_param_idx..end_param_idx].map { |r| r.to_manifest.length }.inject(0) { |sum,x| sum + x }
     new_ws_len = (problem[:arrow_column] - (problem[:newline_indent] + param_length + 1))
     new_ws = ' ' * new_ws_len
 

--- a/lib/puppet-lint/plugins/check_whitespace.rb
+++ b/lib/puppet-lint/plugins/check_whitespace.rb
@@ -202,20 +202,6 @@ PuppetLint.new_check(:arrow_alignment) do
   end
 
   def fix(problem)
-    param_token = problem[:token].prev_code_token
-    if param_token.type == :DQPOST
-      param_length = 0
-      iter_token = param_token
-      while iter_token.type != :DQPRE do
-        param_length += iter_token.to_manifest.length
-        iter_token = iter_token.prev_token
-      end
-      param_length += iter_token.to_manifest.length
-    else
-      param_length = param_token.to_manifest.length
-    end
-    new_ws_len = (problem[:arrow_column] - (problem[:newline_indent] + param_length + 1))
-    new_ws = ' ' * new_ws_len
     if problem[:newline]
       index = tokens.index(problem[:token].prev_code_token.prev_token)
 
@@ -226,6 +212,12 @@ PuppetLint.new_check(:arrow_alignment) do
       problem[:token].prev_code_token.prev_token.type = :INDENT
       problem[:token].prev_code_token.prev_token.value = ' ' * problem[:newline_indent]
     end
+
+    end_param_idx = tokens.index(problem[:token].prev_code_token)
+    start_param_idx = tokens.index(problem[:token].prev_token_of([:INDENT, :NEWLINE])) + 1
+    param_length = tokens[start_param_idx..end_param_idx].map { |r| r.to_manifest.length }.sum
+    new_ws_len = (problem[:arrow_column] - (problem[:newline_indent] + param_length + 1))
+    new_ws = ' ' * new_ws_len
 
     if problem[:token].prev_token.type == :WHITESPACE
       problem[:token].prev_token.value = new_ws

--- a/spec/puppet-lint/plugins/check_whitespace/arrow_alignment_spec.rb
+++ b/spec/puppet-lint/plugins/check_whitespace/arrow_alignment_spec.rb
@@ -803,5 +803,58 @@ describe 'arrow_alignment' do
         expect(manifest).to eq(fixed)
       end
     end
+
+    context 'realignment of resource with an inline single line hash' do
+      let(:code) { <<-END.gsub(/^ {8}/, '')
+        class { 'puppetdb':
+          database                => 'embedded',
+          #database                => 'postgres',
+          #postgres_version        => '9.3',
+          java_args               => { '-Xmx' => '512m', '-Xms' => '256m' },
+          listen_address          => $::ipaddress_eth0,
+          listen_port             => 4998,
+          ssl_listen_address      => $::ipaddress_eth0,
+          ssl_listen_port         => 4999,
+          open_listen_port        => false,
+          open_ssl_listen_port    => false;
+        }
+        END
+      }
+
+      let(:fixed) { <<-END.gsub(/^ {8}/, '')
+        class { 'puppetdb':
+          database             => 'embedded',
+          #database                => 'postgres',
+          #postgres_version        => '9.3',
+          java_args            => { '-Xmx' => '512m', '-Xms' => '256m' },
+          listen_address       => $::ipaddress_eth0,
+          listen_port          => 4998,
+          ssl_listen_address   => $::ipaddress_eth0,
+          ssl_listen_port      => 4999,
+          open_listen_port     => false,
+          open_ssl_listen_port => false;
+        }
+        END
+      }
+
+      it 'should detect 8 problems' do
+        expect(problems).to have(8).problems
+      end
+
+      it 'should fix 8 problems' do
+        expect(problems).to contain_fixed(sprintf(msg, 24, 27)).on_line(2).in_column(27)
+        expect(problems).to contain_fixed(sprintf(msg, 24, 27)).on_line(5).in_column(27)
+        expect(problems).to contain_fixed(sprintf(msg, 24, 27)).on_line(6).in_column(27)
+        expect(problems).to contain_fixed(sprintf(msg, 24, 27)).on_line(7).in_column(27)
+        expect(problems).to contain_fixed(sprintf(msg, 24, 27)).on_line(8).in_column(27)
+        expect(problems).to contain_fixed(sprintf(msg, 24, 27)).on_line(9).in_column(27)
+        expect(problems).to contain_fixed(sprintf(msg, 24, 27)).on_line(10).in_column(27)
+        expect(problems).to contain_fixed(sprintf(msg, 24, 27)).on_line(11).in_column(27)
+      end
+
+      it 'should realign the arrows' do
+        expect(manifest).to eq(fixed)
+      end
+    end
   end
 end

--- a/spec/puppet-lint/plugins/check_whitespace/arrow_alignment_spec.rb
+++ b/spec/puppet-lint/plugins/check_whitespace/arrow_alignment_spec.rb
@@ -743,5 +743,65 @@ describe 'arrow_alignment' do
         expect(manifest).to eq(fixed)
       end
     end
+
+    context 'complex data structure with multiple token keys' do
+      let(:code) { <<-END.gsub(/^ {8}/, '')
+        class example (
+          $external_ip_base,
+        ) {
+
+          bar { 'xxxxxxxxx':
+            inputs => {
+              'ny' => {
+                "${external_ip_base}.16:443 ${a} ${b} ${c}" => 'foo',
+                'veryveryverylongstring8:443'=> 'foo',
+                'simple'=> 'foo',
+                '3'=> :foo,
+                :baz=> :qux,
+                3=> 3,
+              },
+            },
+          }
+        }
+        END
+      }
+
+      let(:fixed) { <<-END.gsub(/^ {8}/, '')
+        class example (
+          $external_ip_base,
+        ) {
+
+          bar { 'xxxxxxxxx':
+            inputs => {
+              'ny' => {
+                "${external_ip_base}.16:443 ${a} ${b} ${c}" => 'foo',
+                'veryveryverylongstring8:443'               => 'foo',
+                'simple'                                    => 'foo',
+                '3'                                         => :foo,
+                :baz                                        => :qux,
+                3                                           => 3,
+              },
+            },
+          }
+        }
+        END
+      }
+
+      it 'should detect 5 problems' do
+        expect(problems).to have(5).problems
+      end
+
+      it 'should fix 5 problems' do
+        expect(problems).to contain_fixed(sprintf(msg, 53, 38)).on_line(9).in_column(38)
+        expect(problems).to contain_fixed(sprintf(msg, 53, 17)).on_line(10).in_column(17)
+        expect(problems).to contain_fixed(sprintf(msg, 53, 12)).on_line(11).in_column(12)
+        expect(problems).to contain_fixed(sprintf(msg, 53, 13)).on_line(12).in_column(13)
+        expect(problems).to contain_fixed(sprintf(msg, 53, 10)).on_line(13).in_column(10)
+      end
+
+      it 'should realign the arrows' do
+        expect(manifest).to eq(fixed)
+      end
+    end
   end
 end


### PR DESCRIPTION
#506 ended up having two different issues in it, both related to the arrow_alignment check but distinct.

## Issue 1
```
class example (
  $external_ip_base,
) {

  bar { 'xxxxxxxxxxx':
    inputs => {
      'ny' => {
        "${external_ip_base}.16:443 ${a} ${b} ${c}" => 'foo',
        'veryveryverylongstring8:443'=>'foo',
        'simple'=>'foo',
        '3'=> :foo,
        :baz=> :qux,
        3=> 3,
      },
    },
  }
}
```
Here, the problem was due to the use of colons in the hash. Not good syntax wise, but still shouldn't be behaving as it was. This was caused by how `PuppetLint::Data.resource_indexes` was splitting up the token array into groups of tokens for each resource. We were looking for `:COLON` tokens as the start of the resource, which *shouldn't* appear anywhere else inside the resource, but in this case did. So this resource was actually being split up into multiple resources, throwing the arrow alignment off as we try to align the arrows as far to the left as possible for each resource.

This PR fixes the behaviour of `PuppetLint::Data.resource_indexes` so that it now ignores `:COLON` tokens that reside inside an existing resource.

## Issue 2
```
@@ -28,12 +28,13 @@ class laterpay::core::puppetdb_setup (
             class { 'puppetdb':
    -            database                => 'embedded',
    +            database             => 'embedded',
                 #database                => 'postgres',
                 #postgres_version        => '9.3',
    -            java_args               => { '-Xmx' => '512m', '-Xms' => '256m' },
    -            listen_address          => $::ipaddress_eth0,
    -            listen_port             => 4998,
    -            ssl_listen_address      => $::ipaddress_eth0,
    -            ssl_listen_port         => 4999,
    -            open_listen_port        => false,
    -            open_ssl_listen_port    => false;
    +            java_args            => { '-Xmx'            => '512m',
    + '-Xms'            => '256m' },
    +            listen_address       => $::ipaddress_eth0,
    +            listen_port          => 4998,
    +            ssl_listen_address   => $::ipaddress_eth0,
    +            ssl_listen_port      => 4999,
    +            open_listen_port     => false,
    +            open_ssl_listen_port => false;
             }
```
For this one, the arrow_alignment check was not checking if sub-hashes were on a single line or not, causing them to be split onto multiple lines instead of being left alone (puppet-lint should only attempt to align when the hash or resource is already split over mulitple lines).

This PR fixes this behaviour in the arrow_alignment check by first checking to ensure that all the arrows for a particular hash/resource depth are not all on the same line before checking if the arrows are lined up in the same column.

Fixes #506