### PR TITLE
Ignore selectors when finding resource type

### DIFF
--- a/lib/puppet-lint/data.rb
+++ b/lib/puppet-lint/data.rb
@@ -146,7 +146,9 @@ class PuppetLint::Data
     #
     # Returns a Token object.
     def find_resource_type_token(index)
-      tokens[tokens[0..index].rindex { |token| token.type == :LBRACE }].prev_code_token
+      tokens[tokens[0..index].rindex { |token|
+               token.type == :LBRACE && token.prev_code_token.type != :QMARK
+             }].prev_code_token
     end
 
     # Internal: Find all the Token objects representing the parameter names in

--- a/lib/puppet-lint/data.rb
+++ b/lib/puppet-lint/data.rb
@@ -146,9 +146,10 @@ class PuppetLint::Data
     #
     # Returns a Token object.
     def find_resource_type_token(index)
-      tokens[tokens[0..index].rindex { |token|
-               token.type == :LBRACE && token.prev_code_token.type != :QMARK
-             }].prev_code_token
+      lbrace_idx = tokens[0..index].rindex { |token|
+        token.type == :LBRACE && token.prev_code_token.type != :QMARK
+      }
+      tokens[lbrace_idx].prev_code_token
     end
 
     # Internal: Find all the Token objects representing the parameter names in

--- a/spec/puppet-lint/plugins/check_resources/file_mode_spec.rb
+++ b/spec/puppet-lint/plugins/check_resources/file_mode_spec.rb
@@ -139,6 +139,26 @@ describe 'file_mode' do
         expect(problems).to have(0).problems
       end
     end
+
+    context 'multi body file bad modes selector' do
+      let(:code) { "
+        file {
+          '/tmp/foo1':
+            ensure => $foo ? { default => absent },
+            mode => 644;
+          '/tmp/foo2':
+            mode => 644;
+          '/tmp/foo3':
+            mode => 644;
+         }"
+      }
+
+      it 'should create three warnings' do
+        expect(problems).to contain_warning(sprintf(msg)).on_line(5).in_column(21)
+        expect(problems).to contain_warning(sprintf(msg)).on_line(7).in_column(21)
+        expect(problems).to contain_warning(sprintf(msg)).on_line(9).in_column(21)
+      end
+    end
   end
 
   context 'with fix enabled' do
@@ -223,6 +243,26 @@ describe 'file_mode' do
 
       it 'should not change the manifest' do
         expect(manifest).to eq(code)
+      end
+    end
+
+    context 'multi body file bad modes selector' do
+      let(:code) { "
+        file {
+          '/tmp/foo1':
+            ensure => $foo ? { default => absent },
+            mode => 644;
+          '/tmp/foo2':
+            mode => 644;
+          '/tmp/foo3':
+            mode => 644;
+         }"
+      }
+
+      it 'should fix the manifest' do
+        expect(problems).to contain_fixed(msg).on_line(5).in_column(21)
+        expect(problems).to contain_fixed(msg).on_line(7).in_column(21)
+        expect(problems).to contain_fixed(msg).on_line(9).in_column(21)
       end
     end
   end

--- a/spec/puppet-lint/plugins/check_resources/file_mode_spec.rb
+++ b/spec/puppet-lint/plugins/check_resources/file_mode_spec.rb
@@ -153,6 +153,10 @@ describe 'file_mode' do
          }"
       }
 
+      it 'should detect 3 problems' do
+        expect(problems).to have(3).problems
+      end
+
       it 'should create three warnings' do
         expect(problems).to contain_warning(sprintf(msg)).on_line(5).in_column(21)
         expect(problems).to contain_warning(sprintf(msg)).on_line(7).in_column(21)
@@ -259,10 +263,30 @@ describe 'file_mode' do
          }"
       }
 
-      it 'should fix the manifest' do
+      let(:fixed) { "
+        file {
+          '/tmp/foo1':
+            ensure => $foo ? { default => absent },
+            mode => '0644';
+          '/tmp/foo2':
+            mode => '0644';
+          '/tmp/foo3':
+            mode => '0644';
+         }"
+      }
+
+      it 'should detect 3 problems' do
+        expect(problems).to have(3).problems
+      end
+
+      it 'should fix 3 problems' do
         expect(problems).to contain_fixed(msg).on_line(5).in_column(21)
         expect(problems).to contain_fixed(msg).on_line(7).in_column(21)
         expect(problems).to contain_fixed(msg).on_line(9).in_column(21)
+      end
+
+      it 'should zero pad the file modes and change them to strings' do
+        expect(manifest).to eq(fixed)
       end
     end
   end

--- a/spec/puppet-lint/plugins/check_resources/unquoted_file_mode_spec.rb
+++ b/spec/puppet-lint/plugins/check_resources/unquoted_file_mode_spec.rb
@@ -35,6 +35,26 @@ describe 'unquoted_file_mode' do
         expect(problems).to have(0).problems
       end
     end
+
+    context 'multi body file bad modes selector' do
+      let(:code) { "
+        file {
+          '/tmp/foo1':
+            ensure => $foo ? { default => absent },
+            mode => 644;
+          '/tmp/foo2':
+            mode => 644;
+          '/tmp/foo3':
+            mode => 644;
+         }"
+      }
+
+      it 'should create three warnings' do
+        expect(problems).to contain_warning(sprintf(msg)).on_line(5).in_column(21)
+        expect(problems).to contain_warning(sprintf(msg)).on_line(7).in_column(21)
+        expect(problems).to contain_warning(sprintf(msg)).on_line(9).in_column(21)
+      end
+    end
   end
 
   context 'with fix enabled' do
@@ -87,6 +107,26 @@ describe 'unquoted_file_mode' do
 
       it 'should not change the manifest' do
         expect(manifest).to eq(code)
+      end
+    end
+
+    context 'multi body file bad modes selector' do
+      let(:code) { "
+        file {
+          '/tmp/foo1':
+            ensure => $foo ? { default => absent },
+            mode => 644;
+          '/tmp/foo2':
+            mode => 644;
+          '/tmp/foo3':
+            mode => 644;
+         }"
+      }
+
+      it 'should fix the manifest' do
+        expect(problems).to contain_fixed(msg).on_line(5).in_column(21)
+        expect(problems).to contain_fixed(msg).on_line(7).in_column(21)
+        expect(problems).to contain_fixed(msg).on_line(9).in_column(21)
       end
     end
   end

--- a/spec/puppet-lint/plugins/check_resources/unquoted_file_mode_spec.rb
+++ b/spec/puppet-lint/plugins/check_resources/unquoted_file_mode_spec.rb
@@ -49,6 +49,10 @@ describe 'unquoted_file_mode' do
          }"
       }
 
+      it 'should detect 3 problems' do
+        expect(problems).to have(3).problems
+      end
+
       it 'should create three warnings' do
         expect(problems).to contain_warning(sprintf(msg)).on_line(5).in_column(21)
         expect(problems).to contain_warning(sprintf(msg)).on_line(7).in_column(21)
@@ -123,10 +127,30 @@ describe 'unquoted_file_mode' do
          }"
       }
 
-      it 'should fix the manifest' do
+      let(:fixed) { "
+        file {
+          '/tmp/foo1':
+            ensure => $foo ? { default => absent },
+            mode => '644';
+          '/tmp/foo2':
+            mode => '644';
+          '/tmp/foo3':
+            mode => '644';
+         }"
+      }
+
+      it 'should detect 3 problems' do
+        expect(problems).to have(3).problems
+      end
+
+      it 'should fix 3 problems' do
         expect(problems).to contain_fixed(msg).on_line(5).in_column(21)
         expect(problems).to contain_fixed(msg).on_line(7).in_column(21)
         expect(problems).to contain_fixed(msg).on_line(9).in_column(21)
+      end
+
+      it 'should quote the file modes' do
+        expect(manifest).to eq(fixed)
       end
     end
   end


### PR DESCRIPTION
Merges the changes from #666 with the tests from #667 into one PR

/cc @paran1 @rothsa