### PR TITLE
level_tokens[0] can be nil if there is no params in the top level block

### DIFF
--- a/lib/puppet-lint/data.rb
+++ b/lib/puppet-lint/data.rb
@@ -109,7 +109,7 @@ class PuppetLint::Data
         marker = 0
         result = []
         tokens.select { |t| t.type == :COLON }.each do |colon_token|
-          if colon_token.next_code_token && colon_token.next_code_token != :LBRACE
+          if colon_token.next_code_token && colon_token.next_code_token.type != :LBRACE
             start_idx = tokens.index(colon_token)
             next if start_idx < marker
             end_token = colon_token.next_token_of([:SEMIC, :RBRACE])

--- a/lib/puppet-lint/plugins/check_whitespace.rb
+++ b/lib/puppet-lint/plugins/check_whitespace.rb
@@ -178,7 +178,7 @@ PuppetLint.new_check(:arrow_alignment) do
           level_tokens[level_idx] ||= []
           param_column << nil
         elsif token.type == :RBRACE || token.type == :SEMIC
-          if level_tokens[level_idx].map(&:line).uniq.length > 1
+          if (level_tokens[level_idx] ||= []).map(&:line).uniq.length > 1
             level_tokens[level_idx].each do |arrow_tok|
               unless arrow_tok.column == arrow_column[level_idx] || level_tokens[level_idx].size == 1
                 arrows_on_line = level_tokens[level_idx].select { |t| t.line == arrow_tok.line }

--- a/spec/puppet-lint/plugins/check_whitespace/arrow_alignment_spec.rb
+++ b/spec/puppet-lint/plugins/check_whitespace/arrow_alignment_spec.rb
@@ -424,6 +424,23 @@ describe 'arrow_alignment' do
         expect(problems).to have(0).problems
       end
     end
+
+    context 'where the top level of the block has no parameters' do
+      let(:code) { "
+        case $::osfamily {
+          'RedHat': {
+            $datadir = $::operatingsystem ? {
+              'Amazon' => pick($datadir, 'value'),
+              default  => pick($datadir, 'value'),
+            }
+          }
+        }
+      " }
+
+      it 'should not detect any problems' do
+        expect(problems).to have(0).problems
+      end
+    end
   end
 
   context 'with fix enabled' do


### PR DESCRIPTION
Handle the case where a `{ }` block can exist that has no `=>` in it, but blocks inside that block do (basically only for case statements). `level_tokens` gets initialised when the first `=>` is encountered in the block.

This PR fixes this behaviour by checking if level_tokens[n] is nil and defaulting it to an empty array. Additionally, the behaviour of `PuppetLint::Data#resource_indexes` was inadvertently changed when I missed a call to `type` which resulted in comparing a `PuppetLint::Lexer::Token` object to a symbol.

Fixes #681