### PR TITLE
restore the links between tokens after arrow_on_right_operand_line#fix

### DIFF
--- a/lib/puppet-lint/plugins/check_classes.rb
+++ b/lib/puppet-lint/plugins/check_classes.rb
@@ -35,6 +35,7 @@ PuppetLint.new_check(:arrow_on_right_operand_line) do
   def fix(problem)
     token = problem[:token]
     tokens.delete(token)
+
     # remove any excessive whitespace on the line
     temp_token = token.prev_code_token
     while (temp_token = temp_token.next_token)
@@ -42,9 +43,17 @@ PuppetLint.new_check(:arrow_on_right_operand_line) do
       break if temp_token.type == :NEWLINE
     end
 
+    temp_token.next_token = token
+    token.prev_token = temp_token
     index = tokens.index(token.next_code_token)
     tokens.insert(index, token)
-    tokens.insert(index + 1, PuppetLint::Lexer::Token.new(:WHITESPACE, ' ', 0, 0))
+
+    whitespace_token = PuppetLint::Lexer::Token.new(:WHITESPACE, ' ', temp_token.line + 1, 3)
+    whitespace_token.prev_token = token
+    token.next_token = whitespace_token
+    whitespace_token.next_token = tokens[index + 1]
+    tokens[index + 1].prev_token = whitespace_token
+    tokens.insert(index + 1, whitespace_token)
   end
 
   def whitespace?(token)


### PR DESCRIPTION
Ideally, we would have helper methods to insert and remove tokens that abstracts all this away, but until we do we have to ensure that any `fix` method restores the `next_token` and `prev_token` links after adding or removing tokens from the tokens array.

Fixes #680