### PR TITLE
Add helper methods to add and remove tokens while maintaining the token links

### DIFF
--- a/lib/puppet-lint/checkplugin.rb
+++ b/lib/puppet-lint/checkplugin.rb
@@ -59,6 +59,14 @@ class PuppetLint::CheckPlugin
     PuppetLint::Data.tokens
   end
 
+  def add_token(index, token)
+    PuppetLint::Data.insert(index, token)
+  end
+
+  def remove_token(token)
+    PuppetLint::Data.delete(token)
+  end
+
   # Public: Provides the resource titles to the check plugins.
   #
   # Returns an Array of PuppetLint::Lexer::Token objects.

--- a/lib/puppet-lint/plugins/check_classes/arrow_on_right_operand_line.rb
+++ b/lib/puppet-lint/plugins/check_classes/arrow_on_right_operand_line.rb
@@ -18,26 +18,20 @@ PuppetLint.new_check(:arrow_on_right_operand_line) do
 
   def fix(problem)
     token = problem[:token]
-    tokens.delete(token)
+    remove_token(token)
 
     # remove any excessive whitespace on the line
     temp_token = token.prev_code_token
     while (temp_token = temp_token.next_token)
-      tokens.delete(temp_token) if whitespace?(temp_token)
+      remove_token(temp_token) if whitespace?(temp_token)
       break if temp_token.type == :NEWLINE
     end
 
-    temp_token.next_token = token
-    token.prev_token = temp_token
     index = tokens.index(token.next_code_token)
-    tokens.insert(index, token)
+    add_token(index, token)
 
     whitespace_token = PuppetLint::Lexer::Token.new(:WHITESPACE, ' ', temp_token.line + 1, 3)
-    whitespace_token.prev_token = token
-    token.next_token = whitespace_token
-    whitespace_token.next_token = tokens[index + 1]
-    tokens[index + 1].prev_token = whitespace_token
-    tokens.insert(index + 1, whitespace_token)
+    add_token(index + 1, whitespace_token)
   end
 
   def whitespace?(token)

--- a/lib/puppet-lint/plugins/check_comments/star_comments.rb
+++ b/lib/puppet-lint/plugins/check_comments/star_comments.rb
@@ -26,9 +26,9 @@ PuppetLint.new_check(:star_comments) do
     index = tokens.index(problem[:token].next_token) || 1
     comment_lines.reverse.each do |line|
       indent = problem[:token].prev_token.nil? ? nil : problem[:token].prev_token.value.dup
-      tokens.insert(index, PuppetLint::Lexer::Token.new(:COMMENT, " #{line}", 0, 0))
-      tokens.insert(index, PuppetLint::Lexer::Token.new(:INDENT, indent, 0, 0)) if indent
-      tokens.insert(index, PuppetLint::Lexer::Token.new(:NEWLINE, "\n", 0, 0))
+      add_token(index, PuppetLint::Lexer::Token.new(:COMMENT, " #{line}", 0, 0))
+      add_token(index, PuppetLint::Lexer::Token.new(:INDENT, indent, 0, 0)) if indent
+      add_token(index, PuppetLint::Lexer::Token.new(:NEWLINE, "\n", 0, 0))
     end
   end
 end

--- a/lib/puppet-lint/plugins/check_strings/only_variable_string.rb
+++ b/lib/puppet-lint/plugins/check_strings/only_variable_string.rb
@@ -41,23 +41,9 @@ PuppetLint.new_check(:only_variable_string) do
   end
 
   def fix(problem)
-    prev_token = problem[:start_token].prev_token
-    prev_code_token = problem[:start_token].prev_code_token
-    next_token = problem[:end_token].next_token
-    next_code_token = problem[:end_token].next_code_token
-    var_token = problem[:var_token]
+    remove_token(problem[:start_token])
+    remove_token(problem[:end_token])
 
-    tokens.delete(problem[:start_token])
-    tokens.delete(problem[:end_token])
-
-    prev_token.next_token = var_token unless prev_token.nil?
-    prev_code_token.next_code_token = var_token unless prev_code_token.nil?
-    next_code_token.prev_code_token = var_token unless next_code_token.nil?
-    next_token.prev_token = var_token unless next_token.nil?
-    var_token.type = :VARIABLE
-    var_token.next_token = next_token
-    var_token.next_code_token = next_code_token
-    var_token.prev_code_token = prev_code_token
-    var_token.prev_token = prev_token
+    problem[:var_token].type = :VARIABLE
   end
 end

--- a/spec/puppet-lint/data_spec.rb
+++ b/spec/puppet-lint/data_spec.rb
@@ -1,0 +1,84 @@
+require 'spec_helper'
+
+describe PuppetLint::Data do
+  subject(:data) { PuppetLint::Data }
+  let(:lexer) { PuppetLint::Lexer.new }
+
+  describe '.insert' do
+    let(:manifest) { '$x = $a' }
+    let(:new_token) { PuppetLint::Lexer::Token.new(:PLUS, '+', 0, 0) }
+    let(:original_tokens) { lexer.tokenise(manifest) }
+    let(:tokens) { original_tokens.dup }
+    before do
+      data.tokens = tokens
+      data.insert(2, new_token)
+    end
+
+    it 'adds token at the given index' do
+      expect(data.tokens.map(&:to_manifest).join).to eq '$x += $a'
+    end
+
+    it 'sets the prev_token' do
+      expect(new_token.prev_token).to eq original_tokens[1]
+    end
+
+    it 'sets the prev_code_token' do
+      expect(new_token.prev_code_token).to eq original_tokens[0]
+    end
+
+    it 'sets the next_token' do
+      expect(new_token.next_token).to eq original_tokens[2]
+    end
+
+    it 'sets the next_code_token' do
+      expect(new_token.next_code_token).to eq original_tokens[2]
+    end
+
+    it 'updates the existing next_token' do
+      expect(tokens[1].next_token).to eq new_token
+    end
+
+    it 'updates the existing next_code_token' do
+      expect(tokens[0].next_code_token).to eq new_token
+    end
+
+    it 'updates the existing prev_token' do
+      expect(tokens[3].prev_token).to eq new_token
+    end
+
+    it 'updates the existing prev_code_token' do
+      expect(tokens[3].prev_code_token).to eq new_token
+    end
+  end
+
+  describe '.delete' do
+    let(:manifest) { '$x + = $a' }
+    let(:token) {tokens[2] }
+    let(:original_tokens) { lexer.tokenise(manifest) }
+    let(:tokens) { original_tokens.dup }
+    before do
+      data.tokens = tokens
+      data.delete(token)
+    end
+
+    it 'removes the token' do
+      expect(data.tokens.map(&:to_manifest).join).to eq '$x  = $a'
+    end
+
+    it 'updates the existing next_token' do
+      expect(tokens[1].next_token).to eq original_tokens[3]
+    end
+
+    it 'updates the existing next_code_token' do
+      expect(tokens[0].next_code_token).to eq original_tokens[4]
+    end
+
+    it 'updates the existing prev_token' do
+      expect(tokens[2].prev_token).to eq original_tokens[1]
+    end
+
+    it 'updates the existing prev_code_token' do
+      expect(tokens[3].prev_code_token).to eq original_tokens[0]
+    end
+  end
+end


### PR DESCRIPTION
This make it easier to implement `fix` in plugins, without the risk of breaking puppet-lint (see #684 for ref)
Also it adds tests that the links are maintained, which is not covered by the current specs