### PR TITLE
add five new whitespace checks and fixes

### DIFF
--- a/lib/puppet-lint/plugins/check_whitespace/colon_whitespace_before.rb
+++ b/lib/puppet-lint/plugins/check_whitespace/colon_whitespace_before.rb
@@ -1,0 +1,22 @@
+# Public: Check the manifest tokens for resource type declaration that has no whitespace before a colon and record a warning for each instance found.
+# #
+# https://docs.puppet.com/puppet/latest/style_guide.html#spacing-indentation-and-whitespace
+PuppetLint.new_check(:colon_whitespace_before) do
+  def check
+    tokens.each do |token|
+      next if token.prev_token.nil?
+      if (token.type == :COLON && token.prev_token.type == :WHITESPACE)
+        notify :warning, {
+          :message => 'there should be no space before a colon',
+          :line    => token.line,
+          :column  => token.column,
+          :token   => token,
+        }
+      end
+    end
+  end
+
+  def fix(problem)
+    tokens.delete(problem[:token].prev_token)
+  end
+end

--- a/lib/puppet-lint/plugins/check_whitespace/left_lbrace_whitespace.rb
+++ b/lib/puppet-lint/plugins/check_whitespace/left_lbrace_whitespace.rb
@@ -1,0 +1,24 @@
+# Public: Check the manifest tokens for whitespace before left bracket that is missing and record a warning for each instance found.
+# #
+# https://docs.puppet.com/puppet/latest/style_guide.html#spacing-indentation-and-whitespace 
+PuppetLint.new_check(:left_lbrace_whitespace) do
+  def check
+    tokens.each do |token|
+      unless token.next_token.nil?
+        if (token.type != :WHITESPACE && token.next_token.type == :LBRACE)
+          notify :warning, {
+            :message => 'space needed on left side of opening bracket',
+            :line    => token.line,
+            :column  => token.column,
+            :token   => token,
+          }
+        end
+      end
+    end
+  end
+
+  def fix(problem)
+       index = tokens.index(problem[:token].next_token)
+       tokens.insert(index, PuppetLint::Lexer::Token.new(:WHITESPACE, " ", 0, 0))
+  end
+end

--- a/lib/puppet-lint/plugins/check_whitespace/multiple_whitespace.rb
+++ b/lib/puppet-lint/plugins/check_whitespace/multiple_whitespace.rb
@@ -1,0 +1,27 @@
+# Public: Check the manifest tokens for multiple spaces in whitespace that is not after a newline and record a warning for each instance found.
+# #
+# https://docs.puppet.com/puppet/latest/style_guide.html#spacing-indentation-and-whitespace
+PuppetLint.new_check(:multiple_whitespace) do
+  def check
+    whitespace_tokens = tokens.select { |r| r.type == :WHITESPACE}
+    whitespace_tokens.each do |token|
+      next if token.next_token.nil?
+      if (token.value != " " && token.prev_token != :NEWLINE)
+        unless [:FARROW, :EQUALS].include?(token.next_token.type)
+          notify :warning, {
+            :message => 'too many spaces',
+            :line    => token.line,
+            :column  => token.column,
+            :token   => token,
+          }
+        end
+      end
+    end
+  end
+
+  def fix(problem)
+    if problem[:token]
+      problem[:token].value = " "
+    end
+  end
+end

--- a/lib/puppet-lint/plugins/check_whitespace/right_lbrace_whitespace.rb
+++ b/lib/puppet-lint/plugins/check_whitespace/right_lbrace_whitespace.rb
@@ -1,0 +1,25 @@
+# Public: Check the manifest tokens for whitespace after the left bracket that is missing and record a warning for each instance found.
+# #
+# https://docs.puppet.com/puppet/latest/style_guide.html#spacing-indentation-and-whitespace
+PuppetLint.new_check(:right_lbrace_whitespace) do
+  def check
+    tokens.each do |token|
+      next if token.next_token.nil?
+      if token.type == :LBRACE 
+        unless [:WHITESPACE, :NEWLINE, :RBRACE].include?(token.next_token.type)
+          notify :warning, {
+            :message => 'space needed on right side of opening bracket',
+            :line    => token.line,
+            :column  => token.column,
+            :token   => token,
+          }
+        end
+      end
+    end
+  end
+
+  def fix(problem)
+    index = tokens.index(problem[:token].next_token)
+    tokens.insert(index, PuppetLint::Lexer::Token.new(:WHITESPACE, " ", 0, 0)) 
+  end
+end

--- a/spec/puppet-lint/plugins/check_whitespace/colon_whitespace_before_spec.rb
+++ b/spec/puppet-lint/plugins/check_whitespace/colon_whitespace_before_spec.rb
@@ -1,0 +1,71 @@
+require 'spec_helper'
+
+describe 'colon_whitespace_before' do
+  let(:msg) { 'there should be no space before a colon' }
+
+  context 'with fix disabled' do
+    context 'resource with space between title and colon' do
+      let(:code) { "file { '/tmp/bad1' : ensure => file; }" }
+
+      it 'should only detect a single problem' do
+        expect(problems).to have(1).problem
+      end
+
+      it 'should create a warning' do
+        expect(problems).to contain_warning(msg).on_line(1).in_column(20)
+      end
+    end
+    
+    context 'valid exec command with whitespace before colon' do
+      let(:code) { %Q{
+        exec { 'set hi noop':
+          command => 'unset x; ( x=hi :; echo "$x" )',
+        }          
+        } 
+      }
+
+      it 'should not detect any problem' do
+        expect(problems).to have(0).problem
+      end
+    end
+  end
+
+  context 'with fix enabled' do
+    before do
+      PuppetLint.configuration.fix = true
+    end
+
+    after do
+      PuppetLint.configuration.fix = false
+    end
+
+    context 'resource with space between title and colon' do
+      let(:code) { "file { '/tmp/bad1' : ensure => file; }" }
+
+      it 'should only detect a single problem' do
+        expect(problems).to have(1).problem
+      end
+
+      it 'should fix the manifest' do
+        expect(problems).to contain_fixed(msg).on_line(1).in_column(20)
+      end
+
+      it 'should remove the title whitespace' do
+        expect(manifest).to eq("file { '/tmp/bad1': ensure => file; }")
+      end
+    end
+    
+    context 'valid exec command with whitespace before colon' do
+      let(:code) { %Q{
+        exec { 'set hi noop':
+          command => 'unset x; ( x=hi :; echo "$x" )',
+        }          
+        } 
+      }
+
+      it 'should not detect any problem' do
+        expect(problems).to have(0).problem
+      end
+    end
+  end
+end

--- a/spec/puppet-lint/plugins/check_whitespace/left_lbrace_whitespace_spec.rb
+++ b/spec/puppet-lint/plugins/check_whitespace/left_lbrace_whitespace_spec.rb
@@ -1,0 +1,79 @@
+require 'spec_helper'
+
+describe 'left_lbrace_whitespace' do
+  let(:msg) { 'space needed on left side of opening bracket' }
+
+  context 'with fix disabled' do
+   context 'incorrect spacing around resource type' do
+      let(:code) { "file{ '/tmp/bad2': ensure => file; }"}
+
+      it 'should detect only one problem' do
+        expect(problems).to have(1).problem
+      end
+
+      it 'should create one warning' do
+        expect(problems).to contain_warning(msg).on_line(1).in_column(1)
+      end
+    end
+   
+    context 'should not detect a problem with json heredoc' do
+      let(:code) { %Q{
+        $value = 'foo'
+        notice @("EOF":json/$)
+          {
+            "hoge": "${value}"
+          }
+        |-EOF
+           }
+      }
+
+      it 'should detect not detect any problem' do
+        expect(problems).to have(0).problem
+      end
+    end
+  end
+
+  context 'with fix enabled' do
+    before do
+      PuppetLint.configuration.fix = true
+    end
+
+    after do
+      PuppetLint.configuration.fix = false
+    end
+
+    context 'incorrect spacing around resource type' do
+      let(:code) { "file{ '/tmp/bad2': ensure => file; }"}
+    
+      let(:fixed) { "file { '/tmp/bad2': ensure => file; }"}
+      
+      it 'should detect only one problem' do
+        expect(problems).to have(1).problem
+      end
+
+      it 'should create one warning' do
+        expect(problems).to contain_fixed(msg).on_line(1).in_column(1)
+      end
+
+      it 'should adjust incorrect resource whitespace' do
+        expect(manifest).to eq(fixed)
+      end
+    end
+    
+    context 'should not detect a problem with json heredoc' do
+      let(:code) { %Q{
+        $value = 'foo'
+        notice @("EOF":json/$)
+          {
+            "hoge": "${value}"
+          }
+        |-EOF
+           }
+      }
+
+      it 'should detect not detect any problem' do
+        expect(problems).to have(0).problem
+      end
+    end
+  end
+end

--- a/spec/puppet-lint/plugins/check_whitespace/multiple_whitespace_spec.rb
+++ b/spec/puppet-lint/plugins/check_whitespace/multiple_whitespace_spec.rb
@@ -1,0 +1,79 @@
+require 'spec_helper'
+
+describe 'multiple_whitespace' do
+  let(:msg) { 'too many spaces' }
+
+  context 'with fix disabled' do
+   context 'incorrect spacing around resource type' do
+      let(:code) { "
+        file   { '/tmp/bad5': ensure => file; }"
+      }
+
+      it 'should only detect one problem' do
+        expect(problems).to have(1).problem
+      end
+
+      it 'should create one warning' do
+        expect(problems).to contain_warning(msg).on_line(2).in_column(13)
+      end
+    end
+
+   context 'not detect a problem within strings with multiple spaces' do
+      let(:code) { "
+        sudo::conf { 'admins':
+          priority => 10,
+          content  => '%admins   ALL=(ALL)   NOPASSWD: ALL',
+        }
+    " }
+
+      it 'should not detect any problem' do
+        expect(problems).to have(0).problem
+      end
+    end
+  end
+
+  context 'with fix enabled' do
+    before do
+      PuppetLint.configuration.fix = true
+    end
+
+    after do
+      PuppetLint.configuration.fix = false
+    end
+
+    context 'incorrect spacing around resource type' do
+      let(:code) { "
+        file   { '/tmp/bad5': ensure => file; }"
+      }
+    
+      let(:fixed) { "
+        file { '/tmp/bad5': ensure => file; }"
+      }
+      
+      it 'should only detect one problem' do
+        expect(problems).to have(1).problem
+      end
+
+      it 'should create one warning' do
+        expect(problems).to contain_fixed(msg).on_line(2).in_column(13)
+      end
+
+      it 'should adjust incorrect resource whitespace' do
+        expect(manifest).to eq(fixed)
+      end
+    end
+   
+    context 'not detect a problem within strings with multiple spaces' do
+      let(:code) { "
+        sudo::conf { 'admins':
+          priority => 10,
+          content  => '%admins   ALL=(ALL)   NOPASSWD: ALL',
+        }
+    " }
+
+      it 'should not detect any problem' do
+        expect(problems).to have(0).problem
+      end
+    end
+  end
+end

--- a/spec/puppet-lint/plugins/check_whitespace/right_lbrace_whitespace_spec.rb
+++ b/spec/puppet-lint/plugins/check_whitespace/right_lbrace_whitespace_spec.rb
@@ -1,0 +1,81 @@
+require 'spec_helper'
+
+describe 'right_lbrace_whitespace' do
+  let(:msg) { 'space needed on right side of opening bracket' }
+
+  context 'with fix disabled' do
+    context 'resource with wrong number of spaces between title and bracket' do
+      let(:code) { "file {'/tmp/bad3': ensure => file; }"}
+
+      it 'should only detect one problem' do
+        expect(problems).to have(1).problem
+      end
+
+      it 'should create one warning' do
+        expect(problems).to contain_warning(msg).on_line(1).in_column(6)
+      end
+    end
+
+    context 'closed empty brackets and newlines should not be a problem' do
+      let(:code) { "
+        case $ntp::config_dir {
+          '/', '/etc', undef: {}
+          default: {
+            file { $ntp::config_dir:
+              ensure  => directory,
+            }
+          }
+        }
+    " }
+
+      it 'should not detect any problems' do
+        expect(problems).to have(0).problem
+      end
+    end
+  end
+
+  context 'with fix enabled' do
+    before do
+      PuppetLint.configuration.fix = true
+    end
+
+    after do
+      PuppetLint.configuration.fix = false
+    end
+
+    context 'resource with wrong number of spaces between title and bracket' do
+      let(:code) { "file {'/tmp/bad3': ensure => file; }"}
+
+      let(:fixed) { "file { '/tmp/bad3': ensure => file; }"}
+
+      it 'should only detect one problem' do
+        expect(problems).to have(1).problem
+      end
+
+      it 'should fix the manifest' do
+        expect(problems).to contain_fixed(msg).on_line(1).in_column(6)
+      end
+
+      it 'should adjust the title whitespace' do
+        expect(manifest).to eq(fixed) 
+      end
+    end
+    
+    context 'closed empty brackets and newlines should not be a problem' do
+      let(:code) { "
+        case $ntp::config_dir {
+          '/', '/etc', undef: {}
+          default: {
+            file { $ntp::config_dir:
+              ensure  => directory,
+            }
+          }
+        }
+    " }
+
+      it 'should not detect any problems' do
+        expect(problems).to have(0).problem
+      end
+    end
+  end
+end


### PR DESCRIPTION
adds checks for https://github.com/rodjek/puppet-lint/issues/651. 

These will create an exception minefield I'm afraid, however, I did try doing the checks isolated to resource and title at first, rather than behavior around braces and colons. Trying both ways, I think we're better off doing it this way because the spacing warnings here are generally the rule rather than the exception.
