### PR TITLE
Add pattern support to rake task

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,13 @@ from being linted:
 PuppetLint.configuration.ignore_paths = ["vendor/**/*.pp"]
 ```
 
+The pattern of files to check can be set with:
+
+``` ruby
+# Defaults to `**/*.pp`
+PuppetLint.configuration.pattern = "modules"
+```
+
 ## Reporting bugs or incorrect results
 
 If you find a bug in puppet-lint or its results, please create an issue in the

--- a/lib/puppet-lint/tasks/puppet-lint.rb
+++ b/lib/puppet-lint/tasks/puppet-lint.rb
@@ -68,6 +68,10 @@ class PuppetLint
           @ignore_paths = PuppetLint.configuration.ignore_paths
         end
 
+        if PuppetLint.configuration.pattern
+          @pattern = PuppetLint.configuration.pattern
+        end
+
         RakeFileUtils.send(:verbose, true) do
           linter = PuppetLint.new
           matched_files = FileList[@pattern]


### PR DESCRIPTION
It's already possible to configure the file glob pattern with:

```ruby
PuppetLint::RakeTask.new :lint do |config|
  # Pattern of files to check, defaults to `**/*.pp`
  config.pattern = 'modules'
end
```

This change adds support to the rake test for the alternate
configuration style using `PuppetLint.configuration.*`:

```ruby
PuppetLint.configuration.pattern = 'modules'
```