### PR TITLE
Take into account length of DQPOST token when updating column number

### DIFF
--- a/lib/puppet-lint/lexer.rb
+++ b/lib/puppet-lint/lexer.rb
@@ -416,7 +416,7 @@ class PuppetLint
             line += value.scan(/(\r\n|\r|\n)/).size
             token_column = column + (ss.pos - value.size)
             tokens << new_token(:DQPOST, value, :line => line, :column => token_column)
-            @column = token_column + 1
+            @column = column + ss.pos + 1
             @line_no = line
           end
         else

--- a/spec/puppet-lint/lexer_spec.rb
+++ b/spec/puppet-lint/lexer_spec.rb
@@ -546,6 +546,25 @@ describe PuppetLint::Lexer do
       expect(token.type).to eq(:FARROW)
       expect(token.column).to eq(12)
     end
+
+    it 'should calculate the column number correctly after an enclosed variable starting with a string' do
+      token = @lexer.tokenise('  "bar${foo}" =>').last
+      expect(token.type).to eq(:FARROW)
+      expect(token.column).to eq(15)
+    end
+
+    it 'should calculate the column number correctly after an enclosed variable ending with a string' do
+      token = @lexer.tokenise('  "${foo}bar" =>').last
+      expect(token.type).to eq(:FARROW)
+      expect(token.column).to eq(15)
+    end
+
+    it 'should calculate the column number correctly after an enclosed variable surround by a string' do
+      token = @lexer.tokenise('  "foo${bar}baz" =>').last
+      expect(token.type).to eq(:FARROW)
+      expect(token.column).to eq(18)
+    end
+
   end
 
   [


### PR DESCRIPTION
I've added rspec tests to help illustrate the issue that was reported in #697 and #698, which appears to be a failure in `PuppetLint.Lexer.tokenise`.  These tests should pass, but are currently failing due to the regression.

Test cases around line 110 of `lexer_spec.rb` show that the `interpolate_string` method appears to be working (https://github.com/rodjek/puppet-lint/blob/master/spec/puppet-lint/lexer_spec.rb#L110), but adding similar tests for the `tokenise` method do not.  They fail with an incorrect column number if there is a string after the variable. e.g. `  "${foo}bar" =>`