### PR TITLE
Chaining arrow syntax fix introduces trailing whitespaces

### DIFF
--- a/lib/puppet-lint/plugins/check_classes/arrow_on_right_operand_line.rb
+++ b/lib/puppet-lint/plugins/check_classes/arrow_on_right_operand_line.rb
@@ -19,23 +19,28 @@ PuppetLint.new_check(:arrow_on_right_operand_line) do
 
   def fix(problem)
     token = problem[:token]
-    remove_token(token)
 
-    # remove any excessive whitespace on the line
-    temp_token = token.prev_code_token
-    while (temp_token = temp_token.next_token)
-      remove_token(temp_token) if whitespace?(temp_token)
-      break if temp_token.type == :NEWLINE
+    prev_code_token = token.prev_code_token
+    next_code_token = token.next_code_token
+    indent_token = prev_code_token.prev_token_of(:INDENT)
+
+    # Delete all tokens between the two code tokens the anchor is between
+    temp_token = prev_code_token
+    while (temp_token = temp_token.next_token) and (temp_token != next_code_token)
+      remove_token(temp_token) unless temp_token == token
     end
 
-    index = tokens.index(token.next_code_token)
-    add_token(index, token)
+    # Insert a newline and an indent before the arrow
+    index = tokens.index(token)
+    newline_token = PuppetLint::Lexer::Token.new(:NEWLINE, "\n", token.line, 0)
+    add_token(index, newline_token)
+    if indent_token
+      add_token(index + 1, indent_token)
+    end
 
-    whitespace_token = PuppetLint::Lexer::Token.new(:WHITESPACE, ' ', temp_token.line + 1, 3)
+    # Insert a space between the arrow and the following code token
+    index = tokens.index(token)
+    whitespace_token = PuppetLint::Lexer::Token.new(:WHITESPACE, ' ', token.line, 3)
     add_token(index + 1, whitespace_token)
-  end
-
-  def whitespace?(token)
-    Set[:INDENT, :WHITESPACE].include?(token.type)
   end
 end

--- a/lib/puppet-lint/plugins/check_classes/arrow_on_right_operand_line.rb
+++ b/lib/puppet-lint/plugins/check_classes/arrow_on_right_operand_line.rb
@@ -26,7 +26,7 @@ PuppetLint.new_check(:arrow_on_right_operand_line) do
 
     # Delete all tokens between the two code tokens the anchor is between
     temp_token = prev_code_token
-    while (temp_token = temp_token.next_token) and (temp_token != next_code_token)
+    while (temp_token = temp_token.next_token) && (temp_token != next_code_token)
       remove_token(temp_token) unless temp_token == token
     end
 
@@ -34,9 +34,7 @@ PuppetLint.new_check(:arrow_on_right_operand_line) do
     index = tokens.index(token)
     newline_token = PuppetLint::Lexer::Token.new(:NEWLINE, "\n", token.line, 0)
     add_token(index, newline_token)
-    if indent_token
-      add_token(index + 1, indent_token)
-    end
+    add_token(index + 1, indent_token) if indent_token
 
     # Insert a space between the arrow and the following code token
     index = tokens.index(token)

--- a/spec/puppet-lint/plugins/check_classes/arrow_on_right_operand_line_spec.rb
+++ b/spec/puppet-lint/plugins/check_classes/arrow_on_right_operand_line_spec.rb
@@ -11,7 +11,8 @@ describe 'arrow_on_right_operand_line' do
 
       context 'arrow on the line of left operand' do
         let(:code) do
-          "Package['httpd']  #{operator}
+          "
+            Package['httpd']  #{operator}
             Service['httpd']"
         end
 
@@ -27,7 +28,8 @@ describe 'arrow_on_right_operand_line' do
           end
 
           let(:fixed) do
-            "Package['httpd']
+            "
+            Package['httpd']
             #{operator} Service['httpd']"
           end
 


### PR DESCRIPTION
  Build the proper chain of tokens for the appropriate placement of the arrow chain, indents, and linefeeds

Fixes #695

#puppethack