### PR TITLE
Permit puppet-lint to load "prerelease" gems

### DIFF
--- a/lib/puppet-lint/optparser.rb
+++ b/lib/puppet-lint/optparser.rb
@@ -66,10 +66,6 @@ class PuppetLint::OptParser
         end
       end
 
-      opts.on('-load-prerelease-plugins', 'Load plugins that ruby deems to be pre-release versions') do
-        PuppetLint.configuration.load_prerelease_plugins = true
-      end
-
       opts.on('-f', '--fix', 'Attempt to automatically fix errors') do
         PuppetLint.configuration.fix = true
       end

--- a/lib/puppet-lint/optparser.rb
+++ b/lib/puppet-lint/optparser.rb
@@ -66,6 +66,10 @@ class PuppetLint::OptParser
         end
       end
 
+      opts.on('-load-prerelease-plugins', 'Load plugins that ruby deems to be pre-release versions') do
+        PuppetLint.configuration.load_prerelease_plugins = true
+      end
+
       opts.on('-f', '--fix', 'Attempt to automatically fix errors') do
         PuppetLint.configuration.fix = true
       end

--- a/lib/puppet-lint/plugins.rb
+++ b/lib/puppet-lint/plugins.rb
@@ -40,7 +40,7 @@ class PuppetLint
     # Returns an Array of Gem::Specification objects.
     def self.gemspecs
       @gemspecs ||= if Gem::Specification.respond_to?(:latest_specs)
-        Gem::Specification.latest_specs
+        Gem::Specification.latest_specs(!PuppetLint.configuration.load_prerelease_plugins)
       else
         Gem.searcher.init_gemspecs
       end

--- a/lib/puppet-lint/plugins.rb
+++ b/lib/puppet-lint/plugins.rb
@@ -40,7 +40,11 @@ class PuppetLint
     # Returns an Array of Gem::Specification objects.
     def self.gemspecs
       @gemspecs ||= if Gem::Specification.respond_to?(:latest_specs)
-        Gem::Specification.latest_specs(!PuppetLint.configuration.load_prerelease_plugins)
+        # Environment variable to load prerelease plugins (which ruby defines as
+        # any gem which has a letter in its version number). Can't use puppet-lint configuration
+        # object here because this code executes before the command line is parsed.
+        load_prerelease_plugins = ENV.key?('PUPPET_LINT_LOAD_PRERELEASE_PLUGINS')
+        Gem::Specification.latest_specs(load_prerelease_plugins)
       else
         Gem.searcher.init_gemspecs
       end

--- a/lib/puppet-lint/plugins.rb
+++ b/lib/puppet-lint/plugins.rb
@@ -40,9 +40,11 @@ class PuppetLint
     # Returns an Array of Gem::Specification objects.
     def self.gemspecs
       @gemspecs ||= if Gem::Specification.respond_to?(:latest_specs)
-        # The 'true' allows it to load prerelease plugins (which ruby defines as
-        # any gem which has a letter in its version number).
-        Gem::Specification.latest_specs(true)
+        # Environment variable to load prerelease plugins (which ruby defines as
+        # any gem which has a letter in its version number). Can't use puppet-lint configuration
+        # object here because this code executes before the command line is parsed.
+        load_prerelease_plugins = ENV.key?('PUPPET_LINT_LOAD_PRERELEASE_PLUGINS')
+        Gem::Specification.latest_specs(load_prerelease_plugins)
       else
         Gem.searcher.init_gemspecs
       end

--- a/lib/puppet-lint/plugins.rb
+++ b/lib/puppet-lint/plugins.rb
@@ -40,11 +40,9 @@ class PuppetLint
     # Returns an Array of Gem::Specification objects.
     def self.gemspecs
       @gemspecs ||= if Gem::Specification.respond_to?(:latest_specs)
-        # Environment variable to load prerelease plugins (which ruby defines as
-        # any gem which has a letter in its version number). Can't use puppet-lint configuration
-        # object here because this code executes before the command line is parsed.
-        load_prerelease_plugins = ENV.key?('PUPPET_LINT_LOAD_PRERELEASE_PLUGINS')
-        Gem::Specification.latest_specs(load_prerelease_plugins)
+        # The 'true' allows it to load prerelease plugins (which ruby defines as
+        # any gem which has a letter in its version number).
+        Gem::Specification.latest_specs(true)
       else
         Gem.searcher.init_gemspecs
       end

--- a/lib/puppet-lint/plugins.rb
+++ b/lib/puppet-lint/plugins.rb
@@ -40,14 +40,22 @@ class PuppetLint
     # Returns an Array of Gem::Specification objects.
     def self.gemspecs
       @gemspecs ||= if Gem::Specification.respond_to?(:latest_specs)
-        # Environment variable to load prerelease plugins (which ruby defines as
-        # any gem which has a letter in its version number). Can't use puppet-lint configuration
-        # object here because this code executes before the command line is parsed.
-        load_prerelease_plugins = ENV.key?('PUPPET_LINT_LOAD_PRERELEASE_PLUGINS')
-        Gem::Specification.latest_specs(load_prerelease_plugins)
+        Gem::Specification.latest_specs(load_prerelease_plugins?)
       else
         Gem.searcher.init_gemspecs
       end
+    end
+
+    # Internal: Determine whether to load plugins that contain a letter in their version number.
+    #
+    # Returns true if the configuration is set to load "prerelease" gems, false otherwise.
+    def self.load_prerelease_plugins?
+      # Load prerelease plugins (which ruby defines as any gem which has a letter in its version number).
+      # Can't use puppet-lint configuration object here because this code executes before the command line is parsed.
+      if ENV['PUPPET_LINT_LOAD_PRERELEASE_PLUGINS']
+        return %w(true yes).include?(ENV['PUPPET_LINT_LOAD_PRERELEASE_PLUGINS'].downcase)
+      end
+      false
     end
 
     # Internal: Retrieve a list of available gem paths from RubyGems.


### PR DESCRIPTION
We maintain our list of gems by versioning many of them with git SHAs, e.g. "2.2.1.abcdef". However the "prerelease" filter in `Gem::Specification.latest_specs` will filter out any gems that have a letter in their name.

This PR adds the "true" parameter so that all of the gems are loaded. Note that this could be a breaking change if someone is relying on the "prerelease" filtering logic and is not having plugins loaded as a result.