### PR TITLE
Improve handling of unterminated double quoted strings

### DIFF
--- a/lib/puppet-lint.rb
+++ b/lib/puppet-lint.rb
@@ -155,6 +155,10 @@ class PuppetLint
       end
     end
     puts JSON.pretty_generate(json) if configuration.json
+
+    if problems.any? { |p| p[:check] == :syntax }
+      $stderr.puts "Try running `puppet parser validate <file>`"
+    end
   end
 
   # Public: Determine if PuppetLint found any errors in the manifest.

--- a/lib/puppet-lint/checks.rb
+++ b/lib/puppet-lint/checks.rb
@@ -25,10 +25,16 @@ class PuppetLint::Checks
       PuppetLint::Data.tokens = lexer.tokenise(content)
       PuppetLint::Data.parse_control_comments
     rescue PuppetLint::LexerError => e
+      message = if e.reason.nil?
+                  'Syntax error'
+                else
+                  "Syntax error (#{e.reason})"
+                end
+
       problems << {
         :kind     => :error,
         :check    => :syntax,
-        :message  => 'Syntax error (try running `puppet parser validate <file>`)',
+        :message  => message,
         :line     => e.line_no,
         :column   => e.column,
         :fullpath => PuppetLint::Data.fullpath,

--- a/lib/puppet-lint/lexer.rb
+++ b/lib/puppet-lint/lexer.rb
@@ -299,6 +299,11 @@ class PuppetLint
       dq_str_regexp = /(\$\{|(\A|[^\\])(\\\\)*")/m
       scanner = StringScanner.new(string)
       contents = scanner.scan_until(dq_str_regexp)
+
+      if scanner.matched.nil?
+        raise LexerError.new(@line_no, @column, "Double quoted string missing closing quote")
+      end
+
       until scanner.matched.end_with?('"')
         contents += scanner.scan_until(/\}/m)
         contents += scanner.scan_until(dq_str_regexp)

--- a/lib/puppet-lint/lexer.rb
+++ b/lib/puppet-lint/lexer.rb
@@ -13,13 +13,18 @@ class PuppetLint
     # Internal: Get the Integer column number of the location of the error.
     attr_reader :column
 
+    # Internal: Get the String reason for the error (if known).
+    attr_reader :reason
+
     # Internal: Initialise a new PuppetLint::LexerError object.
     #
     # line_no - The Integer line number of the location of the error.
     # column  - The Integer column number of the location of the error.
-    def initialize(line_no, column)
+    # reason  - A String describing the cause of the error (if known).
+    def initialize(line_no, column, reason = nil)
       @line_no = line_no
       @column = column
+      @reason = reason
     end
   end
 

--- a/spec/puppet-lint/bin_spec.rb
+++ b/spec/puppet-lint/bin_spec.rb
@@ -71,7 +71,8 @@ describe PuppetLint::Bin do
     let(:args) { 'spec/fixtures/test/manifests/malformed.pp' }
 
     its(:exitstatus) { is_expected.to eq(1) }
-    its(:stdout) { is_expected.to eq('ERROR: Syntax error (try running `puppet parser validate <file>`) on line 1') }
+    its(:stdout) { is_expected.to eq('ERROR: Syntax error on line 1') }
+    its(:stderr) { is_expected.to eq('Try running `puppet parser validate <file>`') }
   end
 
   context 'when limited to errors only' do

--- a/spec/puppet-lint/lexer_spec.rb
+++ b/spec/puppet-lint/lexer_spec.rb
@@ -61,6 +61,14 @@ describe PuppetLint::Lexer do
     end
   end
 
+  describe '#slurp_string' do
+    it 'raises a LexerError if the string is not terminated' do
+      expect {
+        @lexer.slurp_string('unterminated string')
+      }.to raise_error(PuppetLint::LexerError)
+    end
+  end
+
   context '#get_string_segment' do
     it 'should get a segment with a single terminator' do
       data = StringScanner.new('foo"bar')


### PR DESCRIPTION
Catch unterminated double quoted strings and raise a LexerError (with a meaningful reason). Also, adjusted how the LexerErrors are displayed to accommodate these reasons when present by moving the "Try running puppet parser validate" message to STDERR

Fixes #727