### PR TITLE
Handle SE Linux policy package files

### DIFF
--- a/lib/puppet-lint.rb
+++ b/lib/puppet-lint.rb
@@ -74,6 +74,10 @@ class PuppetLint
     if File.exist? path
       @path = path
       @code = File.open(path, 'r:UTF-8').read
+
+      # Check if the input is an SE Linux policy package file (which also use
+      # the .pp extension), which all have the first 4 bytes 0xf97cff8f.
+      @code = '' if @code[0..3].unpack('V').first == 0xf97cff8f
     end
   end
 

--- a/lib/puppet-lint/configuration.rb
+++ b/lib/puppet-lint/configuration.rb
@@ -149,6 +149,7 @@ class PuppetLint
       self.fix = false
       self.json = false
       self.show_ignored = false
+      self.ignore_paths = ['vendor/**/*.pp']
     end
   end
 end

--- a/spec/puppet-lint/configuration_spec.rb
+++ b/spec/puppet-lint/configuration_spec.rb
@@ -44,14 +44,15 @@ describe PuppetLint::Configuration do
     subject.defaults
 
     expect(subject.settings).to eq({
-      'with_filename' => false,
+      'with_filename'    => false,
       'fail_on_warnings' => false,
-      'error_level' => :all,
-      'log_format' => '',
-      'with_context' => false,
-      'fix' => false,
-      'show_ignored' => false,
-      'json' => false,
+      'error_level'      => :all,
+      'log_format'       => '',
+      'with_context'     => false,
+      'fix'              => false,
+      'show_ignored'     => false,
+      'json'             => false,
+      'ignore_paths'     => ['vendor/**/*.pp'],
     })
   end
 end


### PR DESCRIPTION
As raised in #714, puppet-lint fails hard when it encounters an SE Linux policy package (which unfortunately also uses the `.pp` extension).

This change clears out the read manifest data if the first 4 bytes of the file are 0xF97CFF8F (as defined in the policy package file format), which effectively makes puppet-lint silently skip over these files.

Additionally, as brought up in the same issue, puppet-lint now sets the default ignore_paths to include `vendor/**/*.pp` for a nicer default experience for bundler users.

Fixes #714