### PR TITLE
Split control comments into words before parsing

### DIFF
--- a/spec/puppet-lint/ignore_overrides_spec.rb
+++ b/spec/puppet-lint/ignore_overrides_spec.rb
@@ -106,4 +106,24 @@ describe 'quoted_booleans', :type => :lint do
       expect(problems).to contain_ignored(msg).on_line(1).in_column(1).with_reason('a reason')
     end
   end
+
+  context 'disable multiple checks in a block' do
+    let(:code) { "
+      # lint:ignore:double_quoted_string lint:ignore:quoted_booleans lint:ignore:arrow_alignment
+      foo { \"bar\":
+        test => 'true',
+        other_test => 'false',
+      }
+      # lint:endignore
+    " }
+
+    it 'should detect 2 problems' do
+      expect(problems).to have(2).problems
+    end
+
+    it 'should ignore both problems' do
+      expect(problems).to contain_ignored(msg).on_line(4).in_column(17).with_reason('')
+      expect(problems).to contain_ignored(msg).on_line(5).in_column(23).with_reason('')
+    end
+  end
 end


### PR DESCRIPTION
The original implementation was flawed because the second capture group in the
regex would be overwritten with the value of the last control comment. Instead
of trying to do it all in one pattern, we now split the comment into words and
parse each one seperately.

Fixes #726