### PR TITLE
Open manifest as binary when writing fixed manifest

### DIFF
--- a/lib/puppet-lint/bin.rb
+++ b/lib/puppet-lint/bin.rb
@@ -65,7 +65,7 @@ class PuppetLint::Bin
         end
 
         next unless PuppetLint.configuration.fix && l.problems.none? { |r| r[:check] == :syntax }
-        File.open(f, 'w') do |fd|
+        File.open(f, 'wb') do |fd|
           fd.write(l.manifest)
         end
       end


### PR DESCRIPTION
This will prevent Ruby from changing the line endings depending on the platform puppet-lint is running on when writing the fixed manifest.

Fixes #748