### PR TITLE
Fix setup of default log_format in PuppetLink.configuration when it is empty.

### DIFF
--- a/lib/puppet-lint.rb
+++ b/lib/puppet-lint.rb
@@ -89,7 +89,7 @@ class PuppetLint
   #
   # Returns a format String to be used with String#%.
   def log_format
-    if configuration.log_format == ''
+    if configuration.log_format.nil? || configuration.log_format.empty?
       ## recreate previous old log format as far as thats possible.
       format = '%{KIND}: %{message} on line %{line}'
       format.prepend('%{path} - ') if configuration.with_filename


### PR DESCRIPTION
# Overview

PuppetLink#log_format checks that configuration.log_format == '', but in
fact it receives nil. So nil is not equal ''. No default configuration
is set as result and we get an error in PuppetLint#format_message about
no method % for nil.

This commit fixes it by checking that value is nil? or empty? which is
proper way to determine absent value for configuration.log_format.

# Issues

- https://github.com/rodjek/puppet-lint/issues/756