### PR TITLE
Add spec for issue raised in #754 #756

### DIFF
--- a/spec/puppet-lint/configuration_spec.rb
+++ b/spec/puppet-lint/configuration_spec.rb
@@ -31,13 +31,21 @@ describe PuppetLint::Configuration do
     expect(subject.foobarbaz).to be_nil
   end
 
-  it 'should create options on the fly' do
+  it 'should be able to explicitly add options' do
     subject.add_option('bar')
 
     expect(subject.bar).to be_nil
 
     subject.bar = 'aoeui'
     expect(subject.bar).to eq('aoeui')
+  end
+
+  it 'should be able to add options on the fly' do
+    expect(subject.test_option).to eq(nil)
+
+    subject.test_option = 'test'
+
+    expect(subject.test_option).to eq('test')
   end
 
   it 'should be able to set sane defaults' do


### PR DESCRIPTION
This part of the method_missing code path was not tested before, leading to the issues in the 2.3.1 release (fixed in #755). This new test (tested by reverting locally to 2.3.1 and confirmed that it does recreate the issue) will prevent a similar regression from going unnoticed in the future.