### PR TITLE
Don't override ignore_paths set in rake task with default value

### DIFF
--- a/lib/puppet-lint/tasks/puppet-lint.rb
+++ b/lib/puppet-lint/tasks/puppet-lint.rb
@@ -65,7 +65,7 @@ class PuppetLint
         end
 
         if PuppetLint.configuration.ignore_paths
-          @ignore_paths = PuppetLint.configuration.ignore_paths
+          @ignore_paths ||= PuppetLint.configuration.ignore_paths
         end
 
         if PuppetLint.configuration.pattern


### PR DESCRIPTION
In #733, `ignore_paths` was given the default value of `['vendor/**/*.pp']`, which unfortunately overrides the `ignore_paths` value given to the rake task via the yielded block.

```ruby
PuppetLint::RakeTask.new(:lint) do |config|
  config.ignore_paths = ['some', 'paths']
end
```

This change will make it so that if the rake task is configured in this fashion, the default value is only applied if the user hasn't supplied their own `ignore_paths` value.

Fixes #760