### PR TITLE
Restore Ruby 1.8.7 support

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -62,7 +62,7 @@ Style/MethodCalledOnDoEndBlock:
 Style/RegexpLiteral:
     EnforcedStyle: percent_r
 Style/TrailingCommaInArguments:
-    EnforcedStyleForMultiline: comma
+    EnforcedStyleForMultiline: no_comma
 Style/TrailingCommaInLiteral:
     EnforcedStyleForMultiline: comma
 Style/FormatStringToken:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ script:
 env:
     - CHECK=test
 rvm:
+  - 1.8.7
   - 1.9.3
   - 2.0.0
   - 2.1.10

--- a/lib/puppet-lint.rb
+++ b/lib/puppet-lint.rb
@@ -8,6 +8,7 @@ require 'puppet-lint/configuration'
 require 'puppet-lint/data'
 require 'puppet-lint/checks'
 require 'puppet-lint/bin'
+require 'puppet-lint/monkeypatches'
 
 class PuppetLint::NoCodeError < StandardError; end
 class PuppetLint::NoFix < StandardError; end

--- a/lib/puppet-lint/checks.rb
+++ b/lib/puppet-lint/checks.rb
@@ -68,7 +68,7 @@ class PuppetLint::Checks
 
     @problems
   rescue => e
-    puts <<-END.gsub(%r{^ {6}}, '')
+    $stdout.puts <<-END.gsub(%r{^ {6}}, '')
       Whoops! It looks like puppet-lint has encountered an error that it doesn't
       know how to handle. Please open an issue at https://github.com/rodjek/puppet-lint
       and paste the following output into the issue description.
@@ -80,7 +80,7 @@ class PuppetLint::Checks
     END
 
     if File.readable?(fileinfo)
-      puts [
+      $stdout.puts [
         'file contents:',
         '```',
         File.read(fileinfo),
@@ -88,7 +88,7 @@ class PuppetLint::Checks
       ].join("\n")
     end
 
-    puts [
+    $stdout.puts [
       'error:',
       '```',
       "#{e.class}: #{e.message}",

--- a/lib/puppet-lint/configuration.rb
+++ b/lib/puppet-lint/configuration.rb
@@ -50,9 +50,9 @@ class PuppetLint
     #
     #   <option>=(value)
     def method_missing(method, *args, &_block)
-      super unless method.to_s =~ %r{^(?<option>\w+)=?$}
+      super unless method.to_s =~ %r{^(\w+)=?$}
 
-      option = Regexp.last_match(:option)
+      option = Regexp.last_match(1)
       add_option(option.to_s) if settings[option].nil?
       settings[option] = args[0] unless args.empty?
     end

--- a/lib/puppet-lint/lexer.rb
+++ b/lib/puppet-lint/lexer.rb
@@ -170,7 +170,7 @@ class PuppetLint
     # \v == vertical tab
     # \f == form feed
     # \p{Zs} == ASCII + Unicode non-linebreaking whitespace
-    WHITESPACE_RE = %r{[\t\v\f\p{Zs}]}
+    WHITESPACE_RE = RUBY_VERSION == '1.8.7' ? %r{[\t\v\f ]} : %r{[\t\v\f\p{Zs}]}
 
     # Internal: Access the internal token storage.
     #
@@ -266,7 +266,7 @@ class PuppetLint
           else
             heredoc_tag = heredoc_queue.shift
             heredoc_name = heredoc_tag[%r{\A"?(.+?)"?(:.+?)?(/.*)?\Z}, 1]
-            str_contents = StringScanner.new(code[i + length..-1]).scan_until(%r{\|?\s*-?\s*#{heredoc_name}})
+            str_contents = StringScanner.new(code[(i + length)..-1]).scan_until(%r{\|?\s*-?\s*#{heredoc_name}})
             interpolate_heredoc(str_contents, heredoc_tag)
             length += str_contents.size
           end
@@ -282,8 +282,8 @@ class PuppetLint
           unless heredoc_queue.empty?
             heredoc_tag = heredoc_queue.shift
             heredoc_name = heredoc_tag[%r{\A"?(.+?)"?(:.+?)?(/.*)?\Z}, 1]
-            str_contents = StringScanner.new(code[i + length..-1]).scan_until(%r{\|?\s*-?\s*#{heredoc_name}})
-            _ = code[0..i + length].split("\n")
+            str_contents = StringScanner.new(code[(i + length)..-1]).scan_until(%r{\|?\s*-?\s*#{heredoc_name}})
+            _ = code[0..(i + length)].split("\n")
             interpolate_heredoc(str_contents, heredoc_tag)
             length += str_contents.size
           end
@@ -557,8 +557,8 @@ class PuppetLint
 
       str = string.scan_until(regexp)
       begin
-        str =~ %r{\A(?<value>.*?)(?<terminator>[$]+|\|?\s*-?#{Regexp.escape(eos_text)})\Z}m
-        [Regexp.last_match(:value), Regexp.last_match(:terminator)]
+        str =~ %r{\A(.*?)([$]+|\|?\s*-?#{Regexp.escape(eos_text)})\Z}m
+        [Regexp.last_match(1), Regexp.last_match(2)]
       rescue
         [nil, nil]
       end

--- a/lib/puppet-lint/monkeypatches.rb
+++ b/lib/puppet-lint/monkeypatches.rb
@@ -1,0 +1,51 @@
+begin
+  '%{test}' % { :test => 'replaced' } == 'replaced' # rubocop:disable Style/FormatString
+rescue
+  # monkeypatch String#% into Ruby 1.8.7
+  class String
+    Percent = instance_method('%') unless defined?(Percent)
+
+    def %(*a, &b)
+      a.flatten!
+
+      string = case a.last
+               when Hash
+                 expand(a.pop)
+               else
+                 self
+               end
+
+      if a.empty?
+        string
+      else
+        Percent.bind(string).call(a, &b)
+      end
+    end
+
+    def expand!(vars = {})
+      loop do
+        changed = false
+        vars.each do |var, value|
+          var = var.to_s
+          var.gsub!(%r{[^a-zA-Z0-9_]}, '')
+          changed = gsub!(%r{\%\{#{var}\}}, value.to_s)
+        end
+        break unless changed
+      end
+      self
+    end
+
+    def expand(opts = {})
+      dup.expand!(opts)
+    end
+  end
+end
+
+unless String.respond_to?(:prepend)
+  # monkeypatch String#prepend into Ruby 1.8.7
+  class String
+    def prepend(lead)
+      replace("#{lead}#{self}")
+    end
+  end
+end

--- a/lib/puppet-lint/optparser.rb
+++ b/lib/puppet-lint/optparser.rb
@@ -44,7 +44,7 @@ class PuppetLint::OptParser
       opts.on(
         '--error-level LEVEL',
         [:all, :warning, :error],
-        'The level of error to return (warning, error or all).',
+        'The level of error to return (warning, error or all).'
       ) do |el|
         PuppetLint.configuration.error_level = el
       end

--- a/lib/puppet-lint/plugins/check_classes/arrow_on_right_operand_line.rb
+++ b/lib/puppet-lint/plugins/check_classes/arrow_on_right_operand_line.rb
@@ -12,7 +12,7 @@ PuppetLint.new_check(:arrow_on_right_operand_line) do
         :message =>  'arrow should be on the right operand\'s line',
         :line    => token.line,
         :column  => token.column,
-        :token   => token,
+        :token   => token
       )
     end
   end

--- a/lib/puppet-lint/plugins/check_classes/autoloader_layout.rb
+++ b/lib/puppet-lint/plugins/check_classes/autoloader_layout.rb
@@ -27,7 +27,7 @@ PuppetLint.new_check(:autoloader_layout) do
         :error,
         :message => "#{title_token.value} not in autoload module layout",
         :line    => title_token.line,
-        :column  => title_token.column,
+        :column  => title_token.column
       )
     end
   end

--- a/lib/puppet-lint/plugins/check_classes/class_inherits_from_params_class.rb
+++ b/lib/puppet-lint/plugins/check_classes/class_inherits_from_params_class.rb
@@ -11,7 +11,7 @@ PuppetLint.new_check(:class_inherits_from_params_class) do
         :warning,
         :message => 'class inheriting from params class',
         :line    => class_idx[:inherited_token].line,
-        :column  => class_idx[:inherited_token].column,
+        :column  => class_idx[:inherited_token].column
       )
     end
   end

--- a/lib/puppet-lint/plugins/check_classes/code_on_top_scope.rb
+++ b/lib/puppet-lint/plugins/check_classes/code_on_top_scope.rb
@@ -13,7 +13,7 @@ PuppetLint.new_check(:code_on_top_scope) do
         :warning,
         :message => "code outside of class or define block - #{token.value}",
         :line    => token.line,
-        :column  => token.column,
+        :column  => token.column
       )
     end
   end

--- a/lib/puppet-lint/plugins/check_classes/inherits_across_namespaces.rb
+++ b/lib/puppet-lint/plugins/check_classes/inherits_across_namespaces.rb
@@ -16,7 +16,7 @@ PuppetLint.new_check(:inherits_across_namespaces) do
         :warning,
         :message => 'class inherits across module namespaces',
         :line    => class_idx[:inherited_token].line,
-        :column  => class_idx[:inherited_token].column,
+        :column  => class_idx[:inherited_token].column
       )
     end
   end

--- a/lib/puppet-lint/plugins/check_classes/names_containing_dash.rb
+++ b/lib/puppet-lint/plugins/check_classes/names_containing_dash.rb
@@ -17,7 +17,7 @@ PuppetLint.new_check(:names_containing_dash) do
         :error,
         :message => "#{obj_type} name containing a dash",
         :line    => class_idx[:name_token].line,
-        :column  => class_idx[:name_token].column,
+        :column  => class_idx[:name_token].column
       )
     end
   end

--- a/lib/puppet-lint/plugins/check_classes/names_containing_uppercase.rb
+++ b/lib/puppet-lint/plugins/check_classes/names_containing_uppercase.rb
@@ -18,7 +18,7 @@ PuppetLint.new_check(:names_containing_uppercase) do
         :message => "#{obj_type} '#{class_idx[:name_token].value}' contains illegal uppercase",
         :line    => class_idx[:name_token].line,
         :column  => class_idx[:name_token].column,
-        :token   => class_idx[:name_token],
+        :token   => class_idx[:name_token]
       )
     end
   end

--- a/lib/puppet-lint/plugins/check_classes/nested_classes_or_defines.rb
+++ b/lib/puppet-lint/plugins/check_classes/nested_classes_or_defines.rb
@@ -19,7 +19,7 @@ PuppetLint.new_check(:nested_classes_or_defines) do
           :warning,
           :message => "#{type} defined inside a class",
           :line    => token.line,
-          :column  => token.column,
+          :column  => token.column
         )
       end
     end

--- a/lib/puppet-lint/plugins/check_classes/parameter_order.rb
+++ b/lib/puppet-lint/plugins/check_classes/parameter_order.rb
@@ -32,7 +32,7 @@ PuppetLint.new_check(:parameter_order) do
           :warning,
           :message => msg,
           :line    => token.line,
-          :column  => token.column,
+          :column  => token.column
         )
       end
     end

--- a/lib/puppet-lint/plugins/check_classes/right_to_left_relationship.rb
+++ b/lib/puppet-lint/plugins/check_classes/right_to_left_relationship.rb
@@ -9,7 +9,7 @@ PuppetLint.new_check(:right_to_left_relationship) do
         :warning,
         :message =>  'right-to-left (<-) relationship',
         :line    => token.line,
-        :column  => token.column,
+        :column  => token.column
       )
     end
   end

--- a/lib/puppet-lint/plugins/check_classes/variable_scope.rb
+++ b/lib/puppet-lint/plugins/check_classes/variable_scope.rb
@@ -132,7 +132,7 @@ PuppetLint.new_check(:variable_scope) do
           :warning,
           :message => msg,
           :line    => token.line,
-          :column  => token.column,
+          :column  => token.column
         )
       end
     end

--- a/lib/puppet-lint/plugins/check_comments/slash_comments.rb
+++ b/lib/puppet-lint/plugins/check_comments/slash_comments.rb
@@ -12,7 +12,7 @@ PuppetLint.new_check(:slash_comments) do
         :message => '// comment found',
         :line    => token.line,
         :column  => token.column,
-        :token   => token,
+        :token   => token
       )
     end
   end

--- a/lib/puppet-lint/plugins/check_comments/star_comments.rb
+++ b/lib/puppet-lint/plugins/check_comments/star_comments.rb
@@ -12,7 +12,7 @@ PuppetLint.new_check(:star_comments) do
         :message => '/* */ comment found',
         :line    => token.line,
         :column  => token.column,
-        :token   => token,
+        :token   => token
       )
     end
   end

--- a/lib/puppet-lint/plugins/check_conditionals/case_without_default.rb
+++ b/lib/puppet-lint/plugins/check_conditionals/case_without_default.rb
@@ -37,7 +37,7 @@ PuppetLint.new_check(:case_without_default) do
         :warning,
         :message => 'case statement without a default case',
         :line    => case_tokens.first.line,
-        :column  => case_tokens.first.column,
+        :column  => case_tokens.first.column
       )
     end
   end

--- a/lib/puppet-lint/plugins/check_conditionals/selector_inside_resource.rb
+++ b/lib/puppet-lint/plugins/check_conditionals/selector_inside_resource.rb
@@ -14,7 +14,7 @@ PuppetLint.new_check(:selector_inside_resource) do
           :warning,
           :message => 'selector inside resource block',
           :line    => token.line,
-          :column  => token.column,
+          :column  => token.column
         )
       end
     end

--- a/lib/puppet-lint/plugins/check_documentation/documentation.rb
+++ b/lib/puppet-lint/plugins/check_documentation/documentation.rb
@@ -24,7 +24,7 @@ PuppetLint.new_check(:documentation) do
         :warning,
         :message => "#{type} not documented",
         :line    => first_token.line,
-        :column  => first_token.column,
+        :column  => first_token.column
       )
     end
   end

--- a/lib/puppet-lint/plugins/check_nodes/unquoted_node_name.rb
+++ b/lib/puppet-lint/plugins/check_nodes/unquoted_node_name.rb
@@ -14,7 +14,7 @@ PuppetLint.new_check(:unquoted_node_name) do
           :check    => :syntax,
           :message  => 'Syntax error (try running `puppet parser validate <file>`)',
           :line     => node.line,
-          :column   => node.column,
+          :column   => node.column
         )
         next
       end
@@ -29,7 +29,7 @@ PuppetLint.new_check(:unquoted_node_name) do
           :message => 'unquoted node name found',
           :line    => token.line,
           :column  => token.column,
-          :token   => token,
+          :token   => token
         )
       end
     end

--- a/lib/puppet-lint/plugins/check_resources/duplicate_params.rb
+++ b/lib/puppet-lint/plugins/check_resources/duplicate_params.rb
@@ -26,7 +26,7 @@ PuppetLint.new_check(:duplicate_params) do
               :error,
               :message => 'duplicate parameter found in resource',
               :line    => prev_token.line,
-              :column  => prev_token.column,
+              :column  => prev_token.column
             )
           else
             seen_params[level] << prev_token.value

--- a/lib/puppet-lint/plugins/check_resources/ensure_first_param.rb
+++ b/lib/puppet-lint/plugins/check_resources/ensure_first_param.rb
@@ -20,7 +20,7 @@ PuppetLint.new_check(:ensure_first_param) do
         :message  => "ensure found on line but it's not the first attribute",
         :line     => ensure_token.line,
         :column   => ensure_token.column,
-        :resource => resource,
+        :resource => resource
       )
     end
   end

--- a/lib/puppet-lint/plugins/check_resources/ensure_not_symlink_target.rb
+++ b/lib/puppet-lint/plugins/check_resources/ensure_not_symlink_target.rb
@@ -20,7 +20,7 @@ PuppetLint.new_check(:ensure_not_symlink_target) do
           :line        => value_token.line,
           :column      => value_token.column,
           :param_token => ensure_token,
-          :value_token => value_token,
+          :value_token => value_token
         )
       end
     end

--- a/lib/puppet-lint/plugins/check_resources/file_mode.rb
+++ b/lib/puppet-lint/plugins/check_resources/file_mode.rb
@@ -26,7 +26,7 @@ PuppetLint.new_check(:file_mode) do
           :message => MSG,
           :line    => value_token.line,
           :column  => value_token.column,
-          :token   => value_token,
+          :token   => value_token
         )
       end
     end

--- a/lib/puppet-lint/plugins/check_resources/unquoted_file_mode.rb
+++ b/lib/puppet-lint/plugins/check_resources/unquoted_file_mode.rb
@@ -20,7 +20,7 @@ PuppetLint.new_check(:unquoted_file_mode) do
           :message => 'unquoted file mode',
           :line    => value_token.line,
           :column  => value_token.column,
-          :token   => value_token,
+          :token   => value_token
         )
       end
     end

--- a/lib/puppet-lint/plugins/check_resources/unquoted_resource_title.rb
+++ b/lib/puppet-lint/plugins/check_resources/unquoted_resource_title.rb
@@ -12,7 +12,7 @@ PuppetLint.new_check(:unquoted_resource_title) do
         :message => 'unquoted resource title',
         :line    => token.line,
         :column  => token.column,
-        :token   => token,
+        :token   => token
       )
     end
   end

--- a/lib/puppet-lint/plugins/check_strings/double_quoted_strings.rb
+++ b/lib/puppet-lint/plugins/check_strings/double_quoted_strings.rb
@@ -16,7 +16,7 @@ PuppetLint.new_check(:double_quoted_strings) do
         :message => 'double quoted string containing no variables',
         :line    => token.line,
         :column  => token.column,
-        :token   => token,
+        :token   => token
       )
     end
   end

--- a/lib/puppet-lint/plugins/check_strings/only_variable_string.rb
+++ b/lib/puppet-lint/plugins/check_strings/only_variable_string.rb
@@ -30,7 +30,7 @@ PuppetLint.new_check(:only_variable_string) do
               :column      => var_token.column,
               :start_token => start_token,
               :var_token   => var_token,
-              :end_token   => eos_token,
+              :end_token   => eos_token
             )
           end
           break

--- a/lib/puppet-lint/plugins/check_strings/puppet_url_without_modules.rb
+++ b/lib/puppet-lint/plugins/check_strings/puppet_url_without_modules.rb
@@ -15,7 +15,7 @@ PuppetLint.new_check(:puppet_url_without_modules) do
         :message => 'puppet:// URL without modules/ found',
         :line    => token.line,
         :column  => token.column,
-        :token   => token,
+        :token   => token
       )
     end
   end

--- a/lib/puppet-lint/plugins/check_strings/quoted_booleans.rb
+++ b/lib/puppet-lint/plugins/check_strings/quoted_booleans.rb
@@ -16,7 +16,7 @@ PuppetLint.new_check(:quoted_booleans) do
         :message => 'quoted boolean value found',
         :line    => token.line,
         :column  => token.column,
-        :token   => token,
+        :token   => token
       )
     end
   end

--- a/lib/puppet-lint/plugins/check_strings/single_quote_string_with_variables.rb
+++ b/lib/puppet-lint/plugins/check_strings/single_quote_string_with_variables.rb
@@ -11,7 +11,7 @@ PuppetLint.new_check(:single_quote_string_with_variables) do
         :error,
         :message => 'single quoted string containing a variable found',
         :line    => token.line,
-        :column  => token.column,
+        :column  => token.column
       )
     end
   end

--- a/lib/puppet-lint/plugins/check_strings/variables_not_enclosed.rb
+++ b/lib/puppet-lint/plugins/check_strings/variables_not_enclosed.rb
@@ -13,7 +13,7 @@ PuppetLint.new_check(:variables_not_enclosed) do
         :message => 'variable not enclosed in {}',
         :line    => token.line,
         :column  => token.column,
-        :token   => token,
+        :token   => token
       )
     end
   end

--- a/lib/puppet-lint/plugins/check_variables/variable_contains_dash.rb
+++ b/lib/puppet-lint/plugins/check_variables/variable_contains_dash.rb
@@ -15,7 +15,7 @@ PuppetLint.new_check(:variable_contains_dash) do
         :warning,
         :message => 'variable contains a dash',
         :line    => token.line,
-        :column  => token.column,
+        :column  => token.column
       )
     end
   end

--- a/lib/puppet-lint/plugins/check_variables/variable_is_lowercase.rb
+++ b/lib/puppet-lint/plugins/check_variables/variable_is_lowercase.rb
@@ -15,7 +15,7 @@ PuppetLint.new_check(:variable_is_lowercase) do
         :warning,
         :message => 'variable contains an uppercase letter',
         :line    => token.line,
-        :column  => token.column,
+        :column  => token.column
       )
     end
   end

--- a/lib/puppet-lint/plugins/check_whitespace/140chars.rb
+++ b/lib/puppet-lint/plugins/check_whitespace/140chars.rb
@@ -14,7 +14,7 @@ PuppetLint.new_check(:'140chars') do
         :warning,
         :message => 'line has more than 140 characters',
         :line    => idx + 1,
-        :column  => 140,
+        :column  => 140
       )
     end
   end

--- a/lib/puppet-lint/plugins/check_whitespace/2sp_soft_tabs.rb
+++ b/lib/puppet-lint/plugins/check_whitespace/2sp_soft_tabs.rb
@@ -13,7 +13,7 @@ PuppetLint.new_check(:'2sp_soft_tabs') do
         :error,
         :message => 'two-space soft tabs not used',
         :line    => token.line,
-        :column  => token.column,
+        :column  => token.column
       )
     end
   end

--- a/lib/puppet-lint/plugins/check_whitespace/80chars.rb
+++ b/lib/puppet-lint/plugins/check_whitespace/80chars.rb
@@ -13,7 +13,7 @@ PuppetLint.new_check(:'80chars') do
         :warning,
         :message => 'line has more than 80 characters',
         :line    => idx + 1,
-        :column  => 80,
+        :column  => 80
       )
     end
   end

--- a/lib/puppet-lint/plugins/check_whitespace/arrow_alignment.rb
+++ b/lib/puppet-lint/plugins/check_whitespace/arrow_alignment.rb
@@ -73,7 +73,7 @@ PuppetLint.new_check(:arrow_alignment) do
                 :token          => arrow_tok,
                 :arrow_column   => arrow_column[level_idx],
                 :newline        => arrows_on_line.index(arrow_tok) != 0,
-                :newline_indent => param_column[level_idx] - 1,
+                :newline_indent => param_column[level_idx] - 1
               )
             end
           end

--- a/lib/puppet-lint/plugins/check_whitespace/hard_tabs.rb
+++ b/lib/puppet-lint/plugins/check_whitespace/hard_tabs.rb
@@ -14,7 +14,7 @@ PuppetLint.new_check(:hard_tabs) do
         :message => 'tab character found',
         :line    => token.line,
         :column  => token.column,
-        :token   => token,
+        :token   => token
       )
     end
   end

--- a/lib/puppet-lint/plugins/check_whitespace/trailing_whitespace.rb
+++ b/lib/puppet-lint/plugins/check_whitespace/trailing_whitespace.rb
@@ -14,7 +14,7 @@ PuppetLint.new_check(:trailing_whitespace) do
         :message => 'trailing whitespace found',
         :line    => token.line,
         :column  => token.column,
-        :token   => token,
+        :token   => token
       )
     end
   end

--- a/spec/puppet-lint/bin_spec.rb
+++ b/spec/puppet-lint/bin_spec.rb
@@ -69,7 +69,7 @@ describe PuppetLint::Bin do
         [
           "#{args[0]} - WARNING: optional parameter listed before required parameter on line 2",
           "#{args[1]} - ERROR: test::foo not in autoload module layout on line 2",
-        ].join("\n"),
+        ].join("\n")
       )
     end
   end
@@ -165,7 +165,7 @@ describe PuppetLint::Bin do
           '',
           "  define test::warning($foo='bar', $baz) { }",
           '                                   ^',
-        ].join("\n"),
+        ].join("\n")
       )
     end
   end
@@ -397,7 +397,7 @@ describe PuppetLint::Bin do
         [
           'IGNORED: double quoted string containing no variables on line 3',
           '  for a good reason',
-        ].join("\n"),
+        ].join("\n")
       )
     end
   end

--- a/spec/puppet-lint/checks_spec.rb
+++ b/spec/puppet-lint/checks_spec.rb
@@ -40,7 +40,7 @@ describe PuppetLint::Checks do
             :column   => 2,
             :path     => anything,
             :fullpath => anything,
-            :filename => anything,
+            :filename => anything
           )
         end
       end
@@ -62,7 +62,7 @@ describe PuppetLint::Checks do
             :column   => 2,
             :path     => anything,
             :fullpath => anything,
-            :filename => anything,
+            :filename => anything
           )
         end
       end
@@ -111,7 +111,7 @@ describe PuppetLint::Checks do
           instance_double(
             PuppetLint::CheckPlugin,
             :run          => [{ :kind => :error, :check => :arrow_alignment }],
-            :fix_problems => [{ :kind => :fixed, :check => :arrow_alignment }],
+            :fix_problems => [{ :kind => :fixed, :check => :arrow_alignment }]
           )
         end
         let(:mock_hard_tabs) do
@@ -203,7 +203,7 @@ describe PuppetLint::Checks do
     end
 
     it 'checks the configuration for each check to see if it is enabled' do
-      expect(enabled_checks.sort).to eq(expected_enabled_checks.sort)
+      expect(enabled_checks.map(&:to_s).sort).to eq(expected_enabled_checks.map(&:to_s).sort)
     end
   end
 

--- a/spec/puppet-lint/configuration_spec.rb
+++ b/spec/puppet-lint/configuration_spec.rb
@@ -60,7 +60,7 @@ describe PuppetLint::Configuration do
       'fix'              => false,
       'show_ignored'     => false,
       'json'             => false,
-      'ignore_paths'     => ['vendor/**/*.pp'],
+      'ignore_paths'     => ['vendor/**/*.pp']
     )
   end
 end

--- a/spec/puppet-lint/lexer_spec.rb
+++ b/spec/puppet-lint/lexer_spec.rb
@@ -1525,7 +1525,7 @@ END
       expect(token.value).to eq("\t")
     end
 
-    it 'should parse unicode spaces' do
+    it 'should parse unicode spaces', :unless => RUBY_VERSION == '1.8.7' do
       token = @lexer.tokenise("\xc2\xa0").first
       expect(token.type).to eq(:WHITESPACE)
       expect(token.value).to eq("\xc2\xa0")

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -131,7 +131,7 @@ RSpec.configure do |config|
   config.include(
     RSpec::LintExampleGroup,
     :type      => :lint,
-    :file_path => Regexp.compile(%w[spec puppet-lint plugins].join('[\\\/]')),
+    :file_path => Regexp.compile(%w[spec puppet-lint plugins].join('[\\\/]'))
   )
 
   config.expect_with(:rspec) do |c|


### PR DESCRIPTION
Ruby 1.8.7 support wasn't supposed to be dropped until 3.x but I accidentally did.

Fixes #759 