### PR TITLE
Add some basic acceptance tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ coverage/
 /_site/
 .idea
 /*.pp
+/tmp/

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ bundler_args: --without development system_tests
 script:
     - bundle exec rake $CHECK
 env:
-    - CHECK=test
+    - CHECK=ci
 rvm:
   - 1.9.3
   - 2.0.0

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,7 @@
 require 'rake'
 require 'rspec/core/rake_task'
 require 'puppet-lint'
+require 'puppet-lint/tasks/release_test'
 
 task :default => :test
 
@@ -26,5 +27,7 @@ begin
 rescue LoadError
   $stderr.puts 'Rubocop is not available for this version of Ruby.'
 end
+
+task :ci => [:test, :release_test]
 
 # vim: syntax=ruby

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,4 +26,4 @@ before_test:
   - bundle -v
 
 test_script:
-  - bundle exec rake test
+  - bundle exec rake ci

--- a/lib/puppet-lint/tasks/release_test.rb
+++ b/lib/puppet-lint/tasks/release_test.rb
@@ -1,0 +1,71 @@
+require 'rake'
+require 'open3'
+
+def run_cmd(message, *cmd)
+  print("  #{message}...")
+
+  output, status = Open3.capture2e(*cmd)
+  if status.success?
+    puts 'Done'
+  else
+    puts 'FAILED'
+  end
+
+  [output.strip, status.success?]
+end
+
+task :release_test do
+  branch = if ENV['APPVEYOR']
+             ENV['APPVEYOR_PULL_REQUEST_HEAD_REPO_BRANCH']
+           elsif ENV['TRAVIS']
+             ENV['TRAVIS_PULL_REQUEST_BRANCH']
+           else
+             false
+           end
+
+  if branch && branch !~ %r{\A\d+_\d+_\d+_release\Z}
+    puts 'Skipping release tests on feature branch'
+    exit
+  end
+
+  modules_to_test = [
+    'puppetlabs/puppetlabs-apt',
+    'puppetlabs/puppetlabs-tomcat',
+    'puppetlabs/puppetlabs-apache',
+    'puppetlabs/puppetlabs-mysql',
+    'puppetlabs/puppetlabs-ntp',
+    'puppetlabs/puppetlabs-chocolatey',
+    'voxpupuli/puppet-archive',
+    'voxpupuli/puppet-collectd',
+    'garethr/garethr-docker',
+    'sensu/sensu-puppet',
+    'jenkinsci/puppet-jenkins',
+  ]
+
+  FileUtils.mkdir_p('tmp')
+  Dir.chdir('tmp') do
+    modules_to_test.each do |module_name|
+      puts "Testing #{module_name}..."
+      module_dir = File.basename(module_name)
+
+      if File.directory?(module_dir)
+        Dir.chdir(module_dir) do
+          _, success = run_cmd('Updating repository', 'git', 'pull', '--rebase')
+          next unless success
+        end
+      else
+        _, success = run_cmd('Cloning repository', 'git', 'clone', "https://github.com/#{module_name}")
+        next unless success
+      end
+
+      Dir.chdir(module_dir) do
+        output, success = run_cmd('Running puppet-lint', 'bundle', 'exec', 'puppet-lint', '--relative', '--no-documentation-check', 'manifests')
+        unless output.empty?
+          output.split("\n").each do |line|
+            puts "    #{line}"
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
In order to hopefully avoid bad releases like 2.3.1, this adds some basic acceptance tests that should run on PRs that create new releases (branch named like `2_3_3_release`).

