### PR TITLE
Add support for passing backslash separated paths to puppet-lint

### DIFF
--- a/lib/puppet-lint/bin.rb
+++ b/lib/puppet-lint/bin.rb
@@ -42,6 +42,7 @@ class PuppetLint::Bin
 
     begin
       path = @args[0]
+      path = path.gsub(File::ALT_SEPARATOR, File::SEPARATOR) if File::ALT_SEPARATOR
       path = if File.directory?(path)
                Dir.glob("#{path}/**/*.pp")
              else

--- a/spec/puppet-lint/bin_spec.rb
+++ b/spec/puppet-lint/bin_spec.rb
@@ -55,6 +55,17 @@ describe PuppetLint::Bin do
     its(:stdout) { is_expected.to eq("puppet-lint #{PuppetLint::VERSION}") }
   end
 
+  context 'when passed a backslash separated path on Windows', :if => Gem.win_platform? do
+    let(:args) do
+      [
+        'spec\fixtures\test\manifests',
+      ]
+    end
+
+    its(:exitstatus) { is_expected.to eq(1) }
+    its(:stdout) { is_expected.to match(%r{spec/fixtures/test/manifests/warning\.pp - WARNING: optional}m) }
+  end
+
   context 'when passed multiple files' do
     let(:args) do
       [


### PR DESCRIPTION
`Dir.glob` does not support backslash separated paths (because backslash is used as an escape character), so if puppet-lint is running on a platform where `File::ALT_SEPARATOR` is defined, substitute any occurrence of it in the path argument with `File::SEPARATOR` before passing the path to `Dir.glob`.