### PR TITLE
Fix setting ignore_paths in Rake task

### DIFF
--- a/lib/puppet-lint/tasks/puppet-lint.rb
+++ b/lib/puppet-lint/tasks/puppet-lint.rb
@@ -64,8 +64,8 @@ class PuppetLint
           PuppetLint.configuration.send("#{config}=".to_sym, value) unless value.nil?
         end
 
-        if PuppetLint.configuration.ignore_paths
-          @ignore_paths ||= PuppetLint.configuration.ignore_paths
+        if PuppetLint.configuration.ignore_paths && @ignore_paths.empty?
+          @ignore_paths = PuppetLint.configuration.ignore_paths
         end
 
         if PuppetLint.configuration.pattern


### PR DESCRIPTION
The value of `PuppetLint.configuration.ignore_paths` was ignored,
as described in issue #774