### PR TITLE
Allow passing ignore_paths from cli

### DIFF
--- a/lib/puppet-lint/bin.rb
+++ b/lib/puppet-lint/bin.rb
@@ -52,9 +52,11 @@ class PuppetLint::Bin
       PuppetLint.configuration.with_filename = true if path.length > 1
 
       return_val = 0
+      ignore_paths = PuppetLint.configuration.ignore_paths
 
       puts '[' if PuppetLint.configuration.json
       path.each do |f|
+        next if ignore_paths.any? { |p| File.fnmatch(p, f) }
         l = PuppetLint.new
         l.file = f
         l.run

--- a/lib/puppet-lint/optparser.rb
+++ b/lib/puppet-lint/optparser.rb
@@ -108,6 +108,10 @@ class PuppetLint::OptParser
         end
       end
 
+      opts.on('--ignore-paths PATHS', 'A comma separated list of patterns to ignore') do |paths|
+        PuppetLint.configuration.ignore_paths = paths.split(',')
+      end
+
       PuppetLint.configuration.checks.each do |check|
         opts.on("--no-#{check}-check", "Skip the #{check} check.") do
           PuppetLint.configuration.send("disable_#{check}")

--- a/spec/puppet-lint/bin_spec.rb
+++ b/spec/puppet-lint/bin_spec.rb
@@ -93,6 +93,19 @@ describe PuppetLint::Bin do
     its(:stderr) { is_expected.to eq('Try running `puppet parser validate <file>`') }
   end
 
+  context 'when passed ignore paths option' do
+    let(:args) do
+      [
+        '--ignore-paths',
+        'spec/*',
+        'spec/fixtures/test/manifests/malformed.pp'
+      ]
+    end
+
+    its(:exitstatus) { is_expected.to eq(0) }
+    its(:stdout) { is_expected.to eq('') }
+  end
+
   context 'when limited to errors only' do
     let(:args) do
       [

--- a/spec/puppet-lint/bin_spec.rb
+++ b/spec/puppet-lint/bin_spec.rb
@@ -98,7 +98,7 @@ describe PuppetLint::Bin do
       [
         '--ignore-paths',
         'spec/*',
-        'spec/fixtures/test/manifests/malformed.pp'
+        'spec/fixtures/test/manifests/malformed.pp',
       ]
     end
 


### PR DESCRIPTION
- define `--ignore-paths` option in optparser
- in `bin.rb` skip paths that match any pattern in `ignore_paths`
- as a consequence this also means ignore_paths will get loaded from .puppet-lint.rc, if any