### PR TITLE
Create a puppet-lint docker image as part of the build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM ruby:latest as builder
+WORKDIR /puppet-lint
+COPY ./ ./
+RUN bundle install --without development system_tests
+RUN bundle exec rake test && \
+  gem build puppet-lint.gemspec
+
+FROM ruby:alpine
+WORKDIR /puppet-lint
+COPY --from=builder /puppet-lint/puppet-lint-*.gem .
+RUN gem install puppet-lint-*.gem && \
+  rm puppet-lint-*.gem
+ENTRYPOINT ["/usr/bin/env", "puppet-lint"]
+CMD ["-h"]


### PR DESCRIPTION
This is a start for #794. I do not have the correct access to set up the entire build process, but it would probably be worth having a look at using dockerhub to do the build automatically.

(Feel free to take over the pull request if it helps).