### PR TITLE
Handle single colon in resource name syntax error

### DIFF
--- a/lib/puppet-lint.rb
+++ b/lib/puppet-lint.rb
@@ -13,6 +13,15 @@ require 'puppet-lint/monkeypatches'
 class PuppetLint::NoCodeError < StandardError; end
 class PuppetLint::NoFix < StandardError; end
 
+# Parser Syntax Errors
+class PuppetLint::SyntaxError < StandardError
+  attr_reader :token
+
+  def initialize(token)
+    @token = token
+  end
+end
+
 # Public: The public interface to puppet-lint.
 class PuppetLint
   # Public: Gets/Sets the String manifest code to be checked.

--- a/lib/puppet-lint/checks.rb
+++ b/lib/puppet-lint/checks.rb
@@ -67,6 +67,19 @@ class PuppetLint::Checks
     end
 
     @problems
+  rescue PuppetLint::SyntaxError => e
+    @problems << {
+      :kind     => :error,
+      :check    => :syntax,
+      :message  => 'Syntax error',
+      :fullpath => File.expand_path(fileinfo, ENV['PWD']),
+      :filename => File.basename(fileinfo),
+      :path     => fileinfo,
+      :line     => e.token.line,
+      :column   => e.token.column,
+    }
+
+    @problems
   rescue => e
     $stdout.puts <<-END.gsub(%r{^ {6}}, '')
       Whoops! It looks like puppet-lint has encountered an error that it doesn't

--- a/lib/puppet-lint/data.rb
+++ b/lib/puppet-lint/data.rb
@@ -176,6 +176,8 @@ class PuppetLint::Data
           end_token = colon_token.next_token_of([:SEMIC, :RBRACE])
           end_idx = tokens.index(end_token)
 
+          raise PuppetLint::SyntaxError, colon_token if end_idx.nil?
+
           result << {
             :start        => start_idx + 1,
             :end          => end_idx,

--- a/spec/puppet-lint/data_spec.rb
+++ b/spec/puppet-lint/data_spec.rb
@@ -4,6 +4,24 @@ describe PuppetLint::Data do
   subject(:data) { PuppetLint::Data }
   let(:lexer) { PuppetLint::Lexer.new }
 
+  describe '.resource_indexes' do
+    before(:each) do
+      data.tokens = lexer.tokenise(manifest)
+    end
+
+    context 'when a namespaced class name contains a single colon' do
+      let(:manifest) { 'class foo:bar { }' }
+
+      it 'raises a SyntaxError' do
+        expect {
+          data.resource_indexes
+        }.to raise_error(PuppetLint::SyntaxError) { |error|
+          expect(error.token).to eq(data.tokens[3])
+        }
+      end
+    end
+  end
+
   describe '.insert' do
     let(:manifest) { '$x = $a' }
     let(:new_token) { PuppetLint::Lexer::Token.new(:PLUS, '+', 0, 0) }


### PR DESCRIPTION
For example:

```
class foo:bar {
}
```

Fixes #801