### PR TITLE
Fix rake task after 9a958401f2

### DIFF
--- a/lib/puppet-lint/tasks/puppet-lint.rb
+++ b/lib/puppet-lint/tasks/puppet-lint.rb
@@ -52,8 +52,8 @@ class PuppetLint
 
       # clear any (auto-)pre-existing task
       Rake::Task[@name].clear if Rake::Task.task_defined?(@name)
-      task @name do
-        PuppetLint::OptParser.build
+      task @name do |_t, rake_args|
+        PuppetLint::OptParser.build(rake_args)
 
         Array(@disable_checks).each do |check|
           PuppetLint.configuration.send("disable_#{check}")


### PR DESCRIPTION
I don't see how any parameter will affect anything, but at least this way `rake lint` works with 2.3.4.