### PR TITLE
Make PuppetLint::OptParser.build argument optional

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,7 @@
 require 'rake'
 require 'rspec/core/rake_task'
 require 'puppet-lint'
-require 'puppet-lint/tasks/release_test' unless RUBY_VERSION.start_with?('1')
+require 'puppet-lint/tasks/release_test'
 
 task :default => :test
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,7 @@
 require 'rake'
 require 'rspec/core/rake_task'
 require 'puppet-lint'
-require 'puppet-lint/tasks/release_test'
+require 'puppet-lint/tasks/release_test' unless RUBY_VERSION.start_with?('1')
 
 task :default => :test
 
@@ -24,6 +24,14 @@ begin
 
   RuboCop::RakeTask.new(:rubocop) do |task|
     task.options = %w[-D -E]
+    task.patterns = [
+      'lib/**/*.rb',
+      'spec/**/*.rb',
+      'bin/*',
+      '*.gemspec',
+      'Gemfile',
+      'Rakefile',
+    ]
   end
 rescue LoadError
   $stderr.puts 'Rubocop is not available for this version of Ruby.'

--- a/lib/puppet-lint/optparser.rb
+++ b/lib/puppet-lint/optparser.rb
@@ -17,7 +17,7 @@ class PuppetLint::OptParser
   # Public: Initialise a new puppet-lint OptionParser.
   #
   # Returns an OptionParser object.
-  def self.build(args)
+  def self.build(args = [])
     noconfig = false
     opt_parser = OptionParser.new do |opts|
       opts.banner = HELP_TEXT
@@ -133,7 +133,9 @@ class PuppetLint::OptParser
         end
       end
     end
-    opt_parser.parse!(args)
+
+    opt_parser.parse!(args) unless args.empty?
+
     unless noconfig
       opt_parser.load('/etc/puppet-lint.rc')
       if ENV.key?('HOME') && File.readable?(ENV['HOME'])

--- a/lib/puppet-lint/tasks/gemfile_rewrite.rb
+++ b/lib/puppet-lint/tasks/gemfile_rewrite.rb
@@ -1,0 +1,20 @@
+require 'parser/current'
+
+# Simple rewriter using whitequark/parser that rewrites the "gem 'puppet-lint'"
+# entry in the module's Gemfile (if present) to instead use the local
+# puppet-lint working directory.
+class GemfileRewrite < Parser::TreeRewriter
+  def on_send(node)
+    _, method_name, *args = *node
+
+    if method_name == :gem
+      gem_name = args.first
+      if gem_name.type == :str && gem_name.children.first == 'puppet-lint'
+        puppet_lint_root = File.expand_path(File.join(__FILE__, '..', '..', '..', '..'))
+        replace(node.location.expression, "gem 'puppet-lint', :path => '#{puppet_lint_root}'")
+      end
+    end
+
+    super
+  end
+end


### PR DESCRIPTION
Makes the argument to `PuppetLint::OptParser.build` optional in order to not introduce a breaking API change (the solution in #811 would work, but would have just worked around the breaking change).

Also, this PR updates the `release_test` rake task that runs before each release is tagged so that it now runs puppet-lint via the rake task (in addition to running it via the CLI as it does currently) so that we don't publish a broken rake task again.

Replaces #811 
Fixes #812 
