### PR TITLE
Run all the checks before fixing problems

### DIFF
--- a/lib/puppet-lint/checks.rb
+++ b/lib/puppet-lint/checks.rb
@@ -54,11 +54,15 @@ class PuppetLint::Checks
   def run(fileinfo, data)
     load_data(fileinfo, data)
 
+    checks_run = []
     enabled_checks.each do |check|
       klass = PuppetLint.configuration.check_object[check].new
       # FIXME: shadowing #problems
       problems = klass.run
+      checks_run << [klass, problems]
+    end
 
+    checks_run.each do |klass, problems|
       if PuppetLint.configuration.fix
         @problems.concat(klass.fix_problems)
       else


### PR DESCRIPTION
Depending on the value of `LANG` and `LC_COLLATE`, the check plugins can be loaded (and therefore registered and run) in different orders on different hosts. This lead to scenarios where the `arrow_on_right_operand_line` would run and mutate the `tokens` array to fix problems before all the data structures in `PuppetLint::Data`were fully populated.

This PR changes the check running logic so that all of the checks are run before any of the detected problems are fixed.

Fixes #776 
Fixes #781 
Fixes #799