### PR TITLE
Check if token still exists before fixing trailing_whitespace

### DIFF
--- a/lib/puppet-lint/plugins/check_whitespace/trailing_whitespace.rb
+++ b/lib/puppet-lint/plugins/check_whitespace/trailing_whitespace.rb
@@ -20,6 +20,8 @@ PuppetLint.new_check(:trailing_whitespace) do
   end
 
   def fix(problem)
+    return if problem[:token].nil?
+
     prev_token = problem[:token].prev_token
     next_token = problem[:token].next_token
     prev_token.next_token = next_token


### PR DESCRIPTION
The main issue was fixed in #815 (ordering the fixing to happen after all the checks have finished), but it also exposed that I wasn't checking the value of the token passed to the fix method for the `trailing_whitespace` check, so this PR fixes that.

Fixes #798 
