### PR TITLE
Less aggressive fix method for arrow_on_right_operand_line

### DIFF
--- a/lib/puppet-lint/plugins/check_classes/arrow_on_right_operand_line.rb
+++ b/lib/puppet-lint/plugins/check_classes/arrow_on_right_operand_line.rb
@@ -9,7 +9,7 @@ PuppetLint.new_check(:arrow_on_right_operand_line) do
 
       notify(
         :warning,
-        :message =>  'arrow should be on the right operand\'s line',
+        :message => "arrow should be on the right operand's line",
         :line    => token.line,
         :column  => token.column,
         :token   => token

--- a/lib/puppet-lint/plugins/check_classes/arrow_on_right_operand_line.rb
+++ b/lib/puppet-lint/plugins/check_classes/arrow_on_right_operand_line.rb
@@ -18,27 +18,23 @@ PuppetLint.new_check(:arrow_on_right_operand_line) do
   end
 
   def fix(problem)
-    token = problem[:token]
+    return if problem[:token].nil?
 
-    prev_code_token = token.prev_code_token
-    next_code_token = token.next_code_token
-    indent_token = prev_code_token.prev_token_of(:INDENT)
+    arrow_token = problem[:token]
+    left_operand_token = arrow_token.prev_code_token
+    right_operand_token = arrow_token.next_code_token
 
-    # Delete all tokens between the two code tokens the anchor is between
-    temp_token = prev_code_token
-    while (temp_token = temp_token.next_token) && (temp_token != next_code_token)
-      remove_token(temp_token) unless temp_token == token
+    # Move arrow token to just before the right operand
+    remove_token(arrow_token)
+    right_operand_index = tokens.index(right_operand_token)
+    add_token(right_operand_index, arrow_token)
+    whitespace_token = PuppetLint::Lexer::Token.new(:WHITESPACE, ' ', right_operand_token.line, 3)
+    add_token(right_operand_index + 1, whitespace_token)
+
+    # Remove trailing whitespace after left operand (if it exists)
+    if left_operand_token.next_token.type == :WHITESPACE
+      trailing_whitespace_token = left_operand_token.next_token
+      remove_token(trailing_whitespace_token) if trailing_whitespace_token.next_token.type == :NEWLINE
     end
-
-    # Insert a newline and an indent before the arrow
-    index = tokens.index(token)
-    newline_token = PuppetLint::Lexer::Token.new(:NEWLINE, "\n", token.line, 0)
-    add_token(index, newline_token)
-    add_token(index + 1, indent_token) if indent_token
-
-    # Insert a space between the arrow and the following code token
-    index = tokens.index(token)
-    whitespace_token = PuppetLint::Lexer::Token.new(:WHITESPACE, ' ', token.line, 3)
-    add_token(index + 1, whitespace_token)
   end
 end

--- a/lib/puppet-lint/plugins/check_classes/arrow_on_right_operand_line.rb
+++ b/lib/puppet-lint/plugins/check_classes/arrow_on_right_operand_line.rb
@@ -32,11 +32,8 @@ PuppetLint.new_check(:arrow_on_right_operand_line) do
     add_token(right_operand_index + 1, whitespace_token)
 
     # Remove trailing whitespace after left operand (if it exists)
-    if left_operand_token.next_token.type == :WHITESPACE
-      trailing_whitespace_token = left_operand_token.next_token
-      if [:NEWLINE, :WHITESPACE].include?(trailing_whitespace_token.next_token.type)
-        remove_token(trailing_whitespace_token)
-      end
-    end
+    return unless left_operand_token.next_token.type == :WHITESPACE
+    trailing_whitespace_token = left_operand_token.next_token
+    remove_token(trailing_whitespace_token) if [:NEWLINE, :WHITESPACE].include?(trailing_whitespace_token.next_token.type)
   end
 end

--- a/lib/puppet-lint/plugins/check_classes/arrow_on_right_operand_line.rb
+++ b/lib/puppet-lint/plugins/check_classes/arrow_on_right_operand_line.rb
@@ -34,7 +34,9 @@ PuppetLint.new_check(:arrow_on_right_operand_line) do
     # Remove trailing whitespace after left operand (if it exists)
     if left_operand_token.next_token.type == :WHITESPACE
       trailing_whitespace_token = left_operand_token.next_token
-      remove_token(trailing_whitespace_token) if trailing_whitespace_token.next_token.type == :NEWLINE
+      if [:NEWLINE, :WHITESPACE].include?(trailing_whitespace_token.next_token.type)
+        remove_token(trailing_whitespace_token)
+      end
     end
   end
 end

--- a/spec/puppet-lint/plugins/check_classes/arrow_on_right_operand_line_spec.rb
+++ b/spec/puppet-lint/plugins/check_classes/arrow_on_right_operand_line_spec.rb
@@ -119,6 +119,48 @@ describe 'arrow_on_right_operand_line' do
           end
         end
       end
+
+      context 'arrow on the line of the left operand with a comment following the arrow' do
+        let(:code) do
+          <<-END
+            Package['httpd'] #{operator} # something
+            Service['httpd']
+          END
+        end
+
+        it 'should detect a problem' do
+          expect(problems).to have(1).problem
+        end
+
+        it 'should create a warning' do
+          expect(problems).to contain_warning(msg).on_line(1).in_column(30)
+        end
+
+        context 'with fix enabled' do
+          before(:each) do
+            PuppetLint.configuration.fix = true
+          end
+
+          after(:each) do
+            PuppetLint.configuration.fix = false
+          end
+
+          let(:fixed) do
+            <<-END.gsub(/^ {2}/, '')
+              Package['httpd'] # something
+              #{operator} Service['httpd']
+            END
+          end
+
+          it 'should fix the problem' do
+            expect(problems).to contain_fixed(msg).on_line(1).in_column(30)
+          end
+
+          it 'should move the arrow to before the right operand' do
+            expect(manifest).to eq(fixed)
+          end
+        end
+      end
     end
   end
 end

--- a/spec/puppet-lint/plugins/check_classes/arrow_on_right_operand_line_spec.rb
+++ b/spec/puppet-lint/plugins/check_classes/arrow_on_right_operand_line_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 describe 'arrow_on_right_operand_line' do
+  msg = "arrow should be on the right operand's line"
+
   { 'chain' => '->', 'subscribe chain' => '~>' }.each do |name, operator|
     context "#{name} operator" do
       context 'both operands on same line' do
@@ -46,6 +48,54 @@ describe 'arrow_on_right_operand_line' do
         end
 
         it { expect(problems).to have(0).problems }
+      end
+
+      context 'arrow on the line of left operand with comment in between' do
+        let(:code) do
+          <<-END
+            Package['httpd'] #{operator}
+
+            # a comment
+            # another comment
+            Service['httpd']
+          END
+        end
+
+        it 'should detect a problem' do
+          expect(problems).to have(1).problem
+        end
+
+        it 'should create a warning' do
+          expect(problems).to contain_warning(msg).on_line(1).in_column(30)
+        end
+
+        context 'with fix enabled' do
+          before(:each) do
+            PuppetLint.configuration.fix = true
+          end
+
+          after(:each) do
+            PuppetLint.configuration.fix = false
+          end
+
+          let(:fixed) do
+            <<-END.gsub(/^ {2}/, '')
+              Package['httpd']
+
+              # a comment
+              # another comment
+              #{operator} Service['httpd']
+            END
+          end
+
+          it 'should fix the problem' do
+            expect(problems).to contain_fixed(msg).on_line(1).in_column(30)
+          end
+
+          it 'should move the arrow to before the right operand' do
+            expect(manifest).to eq(fixed)
+          end
+        end
       end
     end
   end

--- a/spec/puppet-lint/plugins/check_classes/arrow_on_right_operand_line_spec.rb
+++ b/spec/puppet-lint/plugins/check_classes/arrow_on_right_operand_line_spec.rb
@@ -43,7 +43,7 @@ describe 'arrow_on_right_operand_line' do
           end
 
           let(:fixed) do
-            <<-END.gsub(/^ {2}/, '')
+            <<-END.gsub(%r{^ {2}}, '')
               Package['httpd']
               #{operator} Service['httpd']
             END
@@ -101,7 +101,7 @@ describe 'arrow_on_right_operand_line' do
           end
 
           let(:fixed) do
-            <<-END.gsub(/^ {2}/, '')
+            <<-END.gsub(%r{^ {2}}, '')
               Package['httpd']
 
               # a comment
@@ -146,7 +146,7 @@ describe 'arrow_on_right_operand_line' do
           end
 
           let(:fixed) do
-            <<-END.gsub(/^ {2}/, '')
+            <<-END.gsub(%r{^ {2}}, '')
               Package['httpd'] # something
               #{operator} Service['httpd']
             END


### PR DESCRIPTION
The previous behaviour of this fix was far too aggressive. It would remove all the tokens between the two operands and then recreate them, which resulted in any comments between the two operands also being removed from the fixed manifest.

This PR changes the logic so that it simply moves the arrow token to before the right operand and trims any trailing whitespace it created by doing so.

Fixes #792