### PR TITLE
{WIP} (todo) Add better Windows support

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -72,3 +72,5 @@ Style/FileName:
         - 'lib/puppet-lint.rb'
         - 'lib/puppet-lint/tasks/puppet-lint.rb'
         - 'spec/puppet-lint_spec.rb'
+Layout/EndOfLine:
+  Enabled: false

--- a/lib/puppet-lint/optparser.rb
+++ b/lib/puppet-lint/optparser.rb
@@ -138,8 +138,7 @@ class PuppetLint::OptParser
 
     unless noconfig
       opt_parser.load('/etc/puppet-lint.rc')
-      if ENV.key?('HOME') && File.readable?(ENV['HOME'])
-        home_dotfile_path = File.expand_path('~/.puppet-lint.rc')
+      if home_exists?
         opt_parser.load(home_dotfile_path) if File.readable?(home_dotfile_path)
       end
       opt_parser.load('.puppet-lint.rc')
@@ -147,4 +146,14 @@ class PuppetLint::OptParser
 
     opt_parser
   end
+
+  def self.home_exists?
+    ENV.key?('HOME') && File.readable?(ENV['HOME'])
+  end
+  private_class_method :home_exists?
+
+  def self.home_dotfile_path
+    @home_dotfile_path ||= File.expand_path('~/.puppet-lint.rc')
+  end
+  private_class_method :home_dotfile_path
 end

--- a/spec/puppet-lint/bin_spec.rb
+++ b/spec/puppet-lint/bin_spec.rb
@@ -48,6 +48,30 @@ describe PuppetLint::Bin do
     its(:exitstatus) { is_expected.to eq(1) }
   end
 
+  context 'when using puppet lint configuration files' do
+    let(:args) { ['spec/fixtures/test/manifests/fail.pp'] }
+
+    context 'when running with --no--config' do
+      let(:args) { ['--no-config', 'spec/fixtures/test/manifests/fail.pp'] }
+      it 'should ignore lint configuration files' do
+        allow_any_instance_of(OptionParser).to receive(:load).and_raise('Should not load any configuration files')
+        expect(subject.exitstatus).to eq(1)
+      end
+    end
+
+    it 'should attempt to load the configuration file in the current directory' do
+      expect_any_instance_of(OptionParser).to receive(:load).with('.puppet-lint.rc').and_call_original
+      allow_any_instance_of(OptionParser).to receive(:load).and_call_original
+      expect(subject.exitstatus).to eq(1)
+    end
+
+    it 'should attempt to load the configuration file /etc/puppet-lint.rc' do
+      expect_any_instance_of(OptionParser).to receive(:load).with('/etc/puppet-lint.rc').and_call_original
+      allow_any_instance_of(OptionParser).to receive(:load).and_call_original
+      expect(subject.exitstatus).to eq(1)
+    end
+  end
+
   context 'when asked to display version' do
     let(:args) { '--version' }
 

--- a/spec/puppet-lint/bin_spec.rb
+++ b/spec/puppet-lint/bin_spec.rb
@@ -50,7 +50,6 @@ describe PuppetLint::Bin do
 
   context 'when using puppet lint configuration files' do
     let(:args) { ['spec/fixtures/test/manifests/fail.pp'] }
-
     context 'when running with --no--config' do
       let(:args) { ['--no-config', 'spec/fixtures/test/manifests/fail.pp'] }
       it 'should ignore lint configuration files' do
@@ -70,6 +69,22 @@ describe PuppetLint::Bin do
       allow_any_instance_of(OptionParser).to receive(:load).and_call_original
       expect(subject.exitstatus).to eq(1)
     end
+
+    it 'should attempt to load the home configuration file ~/.puppet-lint.rc when it exists' do
+      this_file = File.expand_path(__FILE__)
+      expect(PuppetLint::OptParser).to recieve(:home_exists?).and_return(true)
+#       expect_any_instance_of(File).to receive(:expand_path).with('~/.puppet-lint.rc').and_return(this_file)
+
+# puts ENV.key?('HOME')
+# puts File.readable?(ENV['HOME'])
+
+#       #expect_any_instance_of(OptionParser).to receive(:load).with(this_file).and_return(nil)
+#       allow_any_instance_of(OptionParser).to receive(:load).and_call_original
+#       result = subject
+#       puts "@@ " + result.stdout
+#       expect(result.exitstatus).to eq(1)
+    end
+
   end
 
   context 'when asked to display version' do


### PR DESCRIPTION
- [ ] Has hardcoded `/etc/...` path which makes no sense on Windows
- [ ] Rubocop fails hard on Windows
- [ ] No tests of puppet-lint.rc files