### PR TITLE
Allow for spaces in the heredoc tag

### DIFF
--- a/lib/puppet-lint/lexer.rb
+++ b/lib/puppet-lint/lexer.rb
@@ -228,7 +228,7 @@ class PuppetLint
           interpolate_string(str_contents, lines_parsed.count, lines_parsed.last.length)
           length = str_contents.size + 1
 
-        elsif heredoc_name = chunk[%r{\A@\(("?.+?"?(:.+?)?(/.*?)?)\)}, 1]
+        elsif heredoc_name = chunk[%r{\A@\(("?.+?"?(:.+?)?#{WHITESPACE_RE}*(/.*?)?)\)}, 1]
           heredoc_queue << heredoc_name
           tokens << new_token(:HEREDOC_OPEN, heredoc_name)
           length = heredoc_name.size + 3
@@ -267,7 +267,7 @@ class PuppetLint
             length += indent.size
           else
             heredoc_tag = heredoc_queue.shift
-            heredoc_name = heredoc_tag[%r{\A"?(.+?)"?(:.+?)?(/.*)?\Z}, 1]
+            heredoc_name = heredoc_tag[%r{\A"?(.+?)"?(:.+?)?#{WHITESPACE_RE}*(/.*)?\Z}, 1]
             str_contents = StringScanner.new(code[(i + length)..-1]).scan_until(%r{\|?\s*-?\s*#{heredoc_name}})
             interpolate_heredoc(str_contents, heredoc_tag)
             length += str_contents.size
@@ -283,7 +283,7 @@ class PuppetLint
 
           unless heredoc_queue.empty?
             heredoc_tag = heredoc_queue.shift
-            heredoc_name = heredoc_tag[%r{\A"?(.+?)"?(:.+?)?(/.*)?\Z}, 1]
+            heredoc_name = heredoc_tag[%r{\A"?(.+?)"?(:.+?)?#{WHITESPACE_RE}*(/.*)?\Z}, 1]
             str_contents = StringScanner.new(code[(i + length)..-1]).scan_until(%r{\|?\s*-?\s*#{heredoc_name}})
             _ = code[0..(i + length)].split(LINE_END_RE)
             interpolate_heredoc(str_contents, heredoc_tag)
@@ -493,7 +493,7 @@ class PuppetLint
     # Returns nothing.
     def interpolate_heredoc(string, name)
       ss = StringScanner.new(string)
-      eos_text = name[%r{\A"?(.+?)"?(:.+?)?(/.*)?\Z}, 1]
+      eos_text = name[%r{\A"?(.+?)"?(:.+?)?#{WHITESPACE_RE}*(/.*)?\Z}, 1]
       first = true
       interpolate = name.start_with?('"')
       value, terminator = get_heredoc_segment(ss, eos_text, interpolate)

--- a/spec/puppet-lint/lexer_spec.rb
+++ b/spec/puppet-lint/lexer_spec.rb
@@ -1091,6 +1091,21 @@ END
       expect(tokens[7].line).to eq(5)
       expect(tokens[7].column).to eq(8)
     end
+
+    it 'should handle a heredoc with spaces in the tag' do
+      manifest = <<-END.gsub(%r{^ {6}}, '')
+      $str = @("myheredoc"     /)
+        foo
+        |-myheredoc
+      END
+      tokens = @lexer.tokenise(manifest)
+      expect(tokens.length).to eq(8)
+
+      expect(tokens[4].type).to eq(:HEREDOC_OPEN)
+      expect(tokens[4].value).to eq('"myheredoc"     /')
+      expect(tokens[6].type).to eq(:HEREDOC)
+      expect(tokens[6].value).to eq("  foo\n  ")
+    end
   end
 
   context ':HEREDOC with interpolation' do


### PR DESCRIPTION
Currently, the parser will fail if there is a space in the heredoc tag. This PR updates the heredoc regex to allow for white spaces in the heredoc tag.  With this PR, `@("MYVAR" /)` no longer causes the following error.


file contents:
```
class testing {
  $myvar = @("MYVAR" /)
       Some string
       in a heredoc
       | MYVAR
  notice($myvar)
}

```

error:
```
TypeError: no implicit conversion of nil into String
/Users/user/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/puppet-lint-2.3.6/lib/puppet-lint/lexer.rb:496:in `initialize'
/Users/user/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/puppet-lint-2.3.6/lib/puppet-lint/lexer.rb:496:in `new'
/Users/user/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/puppet-lint-2.3.6/lib/puppet-lint/lexer.rb:496:in `interpolate_heredoc'
/Users/user/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/puppet-lint-2.3.6/lib/puppet-lint/lexer.rb:273:in `tokenise'
/Users/user/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/puppet-lint-2.3.6/lib/puppet-lint/checks.rb:25:in `load_data'
/Users/user/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/puppet-lint-2.3.6/lib/puppet-lint/checks.rb:55:in `run'
/Users/user/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/puppet-lint-2.3.6/lib/puppet-lint.rb:205:in `run'
/Users/user/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/puppet-lint-2.3.6/lib/puppet-lint/bin.rb:66:in `block in run'
/Users/user/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/puppet-lint-2.3.6/lib/puppet-lint/bin.rb:62:in `each'
/Users/user/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/puppet-lint-2.3.6/lib/puppet-lint/bin.rb:62:in `run'
/Users/user/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/puppet-lint-2.3.6/bin/puppet-lint:7:in `<top (required)>'
/Users/user/.rbenv/versions/2.5.1/bin/puppet-lint:23:in `load'
/Users/user/.rbenv/versions/2.5.1/bin/puppet-lint:23:in `<main>'
```
