### PR TITLE
Resource: fix nested ensure error.

### DIFF
--- a/lib/puppet-lint/plugins/check_resources/ensure_first_param.rb
+++ b/lib/puppet-lint/plugins/check_resources/ensure_first_param.rb
@@ -29,9 +29,12 @@ PuppetLint.new_check(:ensure_first_param) do
     first_param_name_token = tokens[problem[:resource][:start]].next_token_of(:NAME)
     first_param_comma_token = first_param_name_token.next_token_of(:COMMA)
     ensure_param_name_token = first_param_comma_token.next_token_of(:NAME, :value => 'ensure')
+
+    raise PuppetLint::NoFix if ensure_param_name_token.nil?
+
     ensure_param_comma_token = ensure_param_name_token.next_token_of([:COMMA, :SEMIC])
 
-    if first_param_name_token.nil? || first_param_comma_token.nil? || ensure_param_name_token.nil? || ensure_param_comma_token.nil?
+    if first_param_name_token.nil? || first_param_comma_token.nil? || ensure_param_comma_token.nil?
       raise PuppetLint::NoFix
     end
 

--- a/spec/puppet-lint/plugins/check_resources/ensure_first_param_spec.rb
+++ b/spec/puppet-lint/plugins/check_resources/ensure_first_param_spec.rb
@@ -224,5 +224,21 @@ describe 'ensure_first_param' do
         expect(manifest).to eq(fixed)
       end
     end
+
+    context 'ensure in nested hash' do
+      let(:code) do
+        <<-END
+          foo::bar { 'bar':
+            opts   => {
+              ensure => present,
+            },
+          },
+        END
+      end
+
+      it 'should create a warning' do
+        expect(problems).to contain_warning(msg).on_line(3).in_column(15)
+      end
+    end
   end
 end


### PR DESCRIPTION
If an ensure statement is defined within a hash inside a resource, then
ensure_param_name_token will end up being set to nil. This is because
first_param_comma_token jumps to the comma that ends the hash.

This is valid puppet syntax, so the linter shouldn't error out.  With
puppet default arguments, it is normal to pass a hash to a class, which
are applied with the * operator, and ensure could be one of the
arguments. For that reason, moving the ensure out of the inner hash will
change the semantics of the code. Instead, just raise a NoFix and the
user will see the warning.