### PR TITLE
Use lookahead assertion for matching function name

### DIFF
--- a/lib/puppet-lint/lexer.rb
+++ b/lib/puppet-lint/lexer.rb
@@ -110,7 +110,7 @@ class PuppetLint
       [:TYPE, %r{\A(Integer|Float|Boolean|Regexp|String|Array|Hash|Resource|Class|Collection|Scalar|Numeric|CatalogEntry|Data|Tuple|Struct|Optional|NotUndef|Variant|Enum|Pattern|Any|Callable|Type|Runtime|Undef|Default)\b}],
       [:CLASSREF, %r{\A(((::){0,1}[A-Z][-\w]*)+)}],
       [:NUMBER, %r{\A\b((?:0[xX][0-9A-Fa-f]+|0?\d+(?:\.\d+)?(?:[eE]-?\d+)?))\b}],
-      [:FUNCTION_NAME, %r{#{NAME_RE}\(}],
+      [:FUNCTION_NAME, %r{#{NAME_RE}(?=\()}],
       [:NAME, NAME_RE],
       [:LBRACK, %r{\A(\[)}],
       [:RBRACK, %r{\A(\])}],

--- a/lib/puppet-lint/lexer.rb
+++ b/lib/puppet-lint/lexer.rb
@@ -32,7 +32,7 @@ class PuppetLint
 
   # Internal: The puppet-lint lexer. Converts your manifest into its tokenised
   # form.
-  class Lexer # rubocop:disable Metrics/ClassLength
+  class Lexer
     def initialize
       @line_no = 1
       @column = 1

--- a/lib/puppet-lint/lexer.rb
+++ b/lib/puppet-lint/lexer.rb
@@ -203,13 +203,12 @@ class PuppetLint
           value = chunk[regex, 1]
           next if value.nil?
 
-          length = value.size
+          i += value.size
           tokens << if type == :NAME && KEYWORDS.include?(value)
                       new_token(value.upcase.to_sym, value)
                     else
                       new_token(type, value)
                     end
-          i += length
           found = true
           break
         end

--- a/lib/puppet-lint/lexer.rb
+++ b/lib/puppet-lint/lexer.rb
@@ -101,12 +101,23 @@ class PuppetLint
       :LPAREN  => true,
     }.freeze
 
+    # Internal: some commonly used regular expressions
+    # \t == tab
+    # \v == vertical tab
+    # \f == form feed
+    # \p{Zs} == ASCII + Unicode non-linebreaking whitespace
+    WHITESPACE_RE = RUBY_VERSION == '1.8.7' ? %r{[\t\v\f ]} : %r{[\t\v\f\p{Zs}]}
+
+    LINE_END_RE = %r{(?:\r\n|\r|\n)}
+
+    NAME_RE = %r{\A((?:(?:::)?[_a-z0-9][-\w]*)(?:::[a-z0-9][-\w]*)*)}
+
     # Internal: An Array of Arrays containing tokens that can be described by
     # a single regular expression.  Each sub-Array contains 2 elements, the
     # name of the token as a Symbol and a regular expression describing the
     # value of the token.
-    NAME_RE = %r{\A(((::)?[_a-z0-9][-\w]*)(::[a-z0-9][-\w]*)*)}
     KNOWN_TOKENS = [
+      [:WHITESPACE, %r{\A(#{WHITESPACE_RE}+)}],
       [:TYPE, %r{\A(Integer|Float|Boolean|Regexp|String|Array|Hash|Resource|Class|Collection|Scalar|Numeric|CatalogEntry|Data|Tuple|Struct|Optional|NotUndef|Variant|Enum|Pattern|Any|Callable|Type|Runtime|Undef|Default)\b}],
       [:CLASSREF, %r{\A(((::){0,1}[A-Z][-\w]*)+)}],
       [:NUMBER, %r{\A\b((?:0[xX][0-9A-Fa-f]+|0?\d+(?:\.\d+)?(?:[eE]-?\d+)?))\b}],
@@ -165,14 +176,6 @@ class PuppetLint
       :SLASH_COMMENT => true,
       :INDENT        => true,
     }.freeze
-
-    # \t == tab
-    # \v == vertical tab
-    # \f == form feed
-    # \p{Zs} == ASCII + Unicode non-linebreaking whitespace
-    WHITESPACE_RE = RUBY_VERSION == '1.8.7' ? %r{[\t\v\f ]} : %r{[\t\v\f\p{Zs}]}
-
-    LINE_END_RE = %r{(?:\r\n|\r|\n)}
 
     # Internal: Access the internal token storage.
     #
@@ -272,10 +275,6 @@ class PuppetLint
             interpolate_heredoc(str_contents, heredoc_tag)
             length += str_contents.size
           end
-
-        elsif whitespace = chunk[%r{\A(#{WHITESPACE_RE}+)}, 1]
-          length = whitespace.size
-          tokens << new_token(:WHITESPACE, whitespace)
 
         elsif eol = chunk[%r{\A(#{LINE_END_RE})}, 1]
           length = eol.size


### PR DESCRIPTION
For some reason using a lookahead assertion for the opening parenthesis
after a function name is much faster for large manifests. The old
version shows some pathologic behaviour and becomes very slow for
manifests with many entries -- as described in #717.

I don't understand why the old version behaves badly. I was able to
reproduce the speedup with Ruby 1.9.3 as well as with 2.3.something.