### PR TITLE
Disable quoted_booleans check by default

### DIFF
--- a/lib/puppet-lint/plugins/check_strings/quoted_booleans.rb
+++ b/lib/puppet-lint/plugins/check_strings/quoted_booleans.rb
@@ -25,3 +25,4 @@ PuppetLint.new_check(:quoted_booleans) do
     problem[:token].type = problem[:token].value.upcase.to_sym
   end
 end
+PuppetLint.configuration.send('disable_quoted_booleans')


### PR DESCRIPTION
The style guide has been updated since this check was written so that
quoted booleans are no longer a warning.

Closes #474
Closes #844