### PR TITLE
Let command line args override config from files

### DIFF
--- a/lib/puppet-lint/optparser.rb
+++ b/lib/puppet-lint/optparser.rb
@@ -18,7 +18,6 @@ class PuppetLint::OptParser
   #
   # Returns an OptionParser object.
   def self.build(args = [])
-    noconfig = false
     opt_parser = OptionParser.new do |opts|
       opts.banner = HELP_TEXT
 
@@ -27,7 +26,7 @@ class PuppetLint::OptParser
       end
 
       opts.on('--no-config', 'Do not load default puppet-lint option files.') do
-        noconfig = true
+        # nothing to do, option is handled differently
       end
 
       opts.on('-c', '--config FILE', 'Load puppet-lint options from file.') do |file|
@@ -134,9 +133,7 @@ class PuppetLint::OptParser
       end
     end
 
-    opt_parser.parse!(args) unless args.empty?
-
-    unless noconfig
+    unless args.include?('--no-config')
       opt_parser.load('/etc/puppet-lint.rc')
       if ENV.key?('HOME') && File.readable?(ENV['HOME'])
         home_dotfile_path = File.expand_path('~/.puppet-lint.rc')
@@ -144,6 +141,8 @@ class PuppetLint::OptParser
       end
       opt_parser.load('.puppet-lint.rc')
     end
+
+    opt_parser.parse!(args) unless args.empty?
 
     opt_parser
   end

--- a/spec/fixtures/test/manifests/two_warnings.pp
+++ b/spec/fixtures/test/manifests/two_warnings.pp
@@ -1,0 +1,5 @@
+# foo
+define test::two_warnings() {
+  $var1-with-dash = 42
+  $VarUpperCase   = false
+}

--- a/spec/puppet-lint/bin_spec.rb
+++ b/spec/puppet-lint/bin_spec.rb
@@ -526,4 +526,45 @@ describe PuppetLint::Bin do
       end
     end
   end
+
+  context 'when overriding config file options with command line options' do
+    context 'and config file sets "--only-checks=variable_contains_dash"' do
+      around(:context) do |example|
+        Dir.mktmpdir do |tmpdir|
+          Dir.chdir(tmpdir) do
+            File.open('.puppet-lint.rc', 'wb') do |f|
+              f.puts('--only-checks=variable_contains_dash')
+            end
+
+            example.run
+          end
+        end
+      end
+
+      context 'and command-line does not override "--only-checks"' do
+        let(:args) do
+          File.join(File.dirname(__FILE__), '..', 'fixtures', 'test', 'manifests', 'two_warnings.pp')
+        end
+
+        its(:exitstatus) { is_expected.to eq(0) }
+        its(:stdout) do
+          is_expected.to eq('WARNING: variable contains a dash on line 3')
+        end
+      end
+
+      context 'and command-line sets "--only-checks=variable_is_lowercase"' do
+        let(:args) do
+          [
+            '--only-checks=variable_is_lowercase',
+            File.join(File.dirname(__FILE__), '..', 'fixtures', 'test', 'manifests', 'two_warnings.pp'),
+          ]
+        end
+
+        its(:exitstatus) { is_expected.to eq(0) }
+        its(:stdout) do
+          is_expected.to eq('WARNING: variable contains an uppercase letter on line 4')
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Arguments given on the command line should override those from
config files. That implies that config files must be read first.
Only peeking into the command line args can show if config files
should be used at all.

This change might break existing setups.

Fixes #879.