### PR TITLE
Allow parsing of regexes as rvalues

### DIFF
--- a/lib/puppet-lint/lexer.rb
+++ b/lib/puppet-lint/lexer.rb
@@ -104,6 +104,7 @@ class PuppetLint
       :IF      => true,
       :ELSIF   => true,
       :LPAREN  => true,
+      :EQUALS  => true,
     }.freeze
 
     # Internal: some commonly used regular expressions

--- a/spec/puppet-lint/plugins/check_classes/variable_scope_spec.rb
+++ b/spec/puppet-lint/plugins/check_classes/variable_scope_spec.rb
@@ -316,4 +316,18 @@ describe 'variable_scope' do
       expect(problems).to contain_warning(msg).on_line(2).in_column(14)
     end
   end
+
+  context 'assigning regex with multiple alternations to variable' do
+    let(:code) do
+      <<-END
+        class gh::issue859 {
+          $regex = /5|6|7/
+        }
+      END
+    end
+
+    it 'should not detect any problems' do
+      expect(problems).to have(0).problems
+    end
+  end
 end


### PR DESCRIPTION
In earlier Puppet version it wasn't possible to assign a regex to
a variable. This has changed somewhere around version 3.5 and regexes
are valid rvalues now. Compare

  https://tickets.puppetlabs.com/browse/PUP-1074