### PR TITLE
Fix escaped ${} enclosure handling when slurping double quoted strings

### DIFF
--- a/lib/puppet-lint/lexer.rb
+++ b/lib/puppet-lint/lexer.rb
@@ -241,7 +241,7 @@ class PuppetLint
             process_string_segments(string_segments)
             length = slurper.consumed_bytes + 1
           rescue PuppetLint::Lexer::StringSlurper::UnterminatedStringError
-            raise PuppetLint::LexerError, @line_no, @column, 'unterminated string'
+            raise PuppetLint::LexerError.new(@line_no, @column, 'unterminated string')
           end
 
         elsif heredoc_name = chunk[%r{\A@\(("?.+?"?(:.+?)?#{WHITESPACE_RE}*(/.*?)?)\)}, 1]

--- a/lib/puppet-lint/lexer/string_slurper.rb
+++ b/lib/puppet-lint/lexer/string_slurper.rb
@@ -103,6 +103,11 @@ class PuppetLint
       end
 
       def start_interp
+        if @segment.last && @segment.last == '\\'
+          read_char
+          return
+        end
+
         if interp_stack.empty?
           scanner.skip(START_INTERP_PATTERN)
           results << [@segment_type, @segment.join]

--- a/spec/puppet-lint/lexer/string_slurper_spec.rb
+++ b/spec/puppet-lint/lexer/string_slurper_spec.rb
@@ -36,11 +36,19 @@ describe PuppetLint::Lexer::StringSlurper do
           end
         end
 
-        context 'an escaped $' do
+        context 'an escaped $var' do
           let(:string) { '\$foo"' }
 
-          it 'does not create an interpolation segment' do
+          it 'does not create an unenclosed variable segment' do
             expect(segments).to eq([[:STRING, '\$foo']])
+          end
+        end
+
+        context 'an escaped ${} enclosure' do
+          let(:string) { '\"\${\"string\"}\""' }
+
+          it 'does not create an interpolation segment' do
+            expect(segments).to eq([[:STRING, '\"\${\"string\"}\"']])
           end
         end
 


### PR DESCRIPTION
Fixes #885 

I think this will also fix #886 but I don't have enough info to accurately reproduce the problem yet.