### PR TITLE
Search end of string before assuming escaped quote

### DIFF
--- a/lib/puppet-lint/lexer/string_slurper.rb
+++ b/lib/puppet-lint/lexer/string_slurper.rb
@@ -37,11 +37,11 @@ class PuppetLint
             end_interp
           elsif unenclosed_variable?
             unenclosed_variable
-          elsif scanner.match?(ESC_DQUOTE_PATTERN)
-            @segment << scanner.scan(ESC_DQUOTE_PATTERN)
           elsif scanner.match?(END_STRING_PATTERN)
             end_string
             break if interp_stack.empty?
+          elsif scanner.match?(ESC_DQUOTE_PATTERN)
+            @segment << scanner.scan(ESC_DQUOTE_PATTERN)
           else
             read_char
           end

--- a/spec/puppet-lint/lexer/string_slurper_spec.rb
+++ b/spec/puppet-lint/lexer/string_slurper_spec.rb
@@ -246,6 +246,30 @@ describe PuppetLint::Lexer::StringSlurper do
           end
         end
 
+        context 'a variable followed by an odd number of backslashes before a double quote' do
+          let(:string) { '${foo}\"bar"' }
+
+          it 'does not let this double quote terminate the string' do
+            expect(segments).to eq([
+              [:STRING, ''],
+              [:INTERP, 'foo'],
+              [:STRING, '\\"bar'],
+            ])
+          end
+        end
+
+        context 'a variable followed by an even number of backslashes before a double quote' do
+          let(:string) { '${foo}\\\\"bar"' }
+
+          it 'recognizes this double quote as the terminator' do
+            expect(segments).to eq([
+              [:STRING, ''],
+              [:INTERP, 'foo'],
+              [:STRING, '\\\\'],
+            ])
+          end
+        end
+
         context 'an interpolation with a complex function chain' do
           let(:string) { '${key} ${flatten([$value]).join("\nkey ")}"' }
 


### PR DESCRIPTION
Since the ESC_DQUOTE_PATTERN accepts any positive number of
backslashes before the double quote, we have to look for
the end of string first.

This should help with issue #891.