### PR TITLE
Speed up calculation of resource indexes

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -45,7 +45,7 @@ Metrics/BlockNesting:
 # Offense count: 2
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 384
+  Max: 385
 
 # Offense count: 20
 Metrics/CyclomaticComplexity:

--- a/lib/puppet-lint/data.rb
+++ b/lib/puppet-lint/data.rb
@@ -171,21 +171,21 @@ class PuppetLint::Data
         tokens.select { |t| t.type == :COLON }.each do |colon_token|
           next unless colon_token.next_code_token && colon_token.next_code_token.type != :LBRACE
 
-          start_idx = tokens.index(colon_token)
-          next if start_idx < marker
+          rel_start_idx = tokens[marker..-1].index(colon_token)
+          break if rel_start_idx.nil?
+          start_idx = rel_start_idx + marker
           end_token = colon_token.next_token_of([:SEMIC, :RBRACE])
-          end_idx = tokens.index(end_token)
-
-          raise PuppetLint::SyntaxError, colon_token if end_idx.nil?
+          rel_end_idx = tokens[start_idx..-1].index(end_token)
+          raise PuppetLint::SyntaxError, colon_token if rel_end_idx.nil?
+          marker = rel_end_idx + start_idx
 
           result << {
             :start        => start_idx + 1,
-            :end          => end_idx,
-            :tokens       => tokens[start_idx..end_idx],
+            :end          => marker,
+            :tokens       => tokens[start_idx..marker],
             :type         => find_resource_type_token(start_idx),
-            :param_tokens => find_resource_param_tokens(tokens[start_idx..end_idx]),
+            :param_tokens => find_resource_param_tokens(tokens[start_idx..marker]),
           }
-          marker = end_idx
         end
         result
       end


### PR DESCRIPTION
By ignoring the already analysed tokens the index operations
on the tokens array become substantially faster for large
manifests. This should solve issue #717.