### PR TITLE
Do not rely on tokens array positioning when fixing ensure_first_param problems

### DIFF
--- a/lib/puppet-lint/plugins/check_resources/ensure_first_param.rb
+++ b/lib/puppet-lint/plugins/check_resources/ensure_first_param.rb
@@ -26,7 +26,7 @@ PuppetLint.new_check(:ensure_first_param) do
   end
 
   def fix(problem)
-    first_param_name_token = tokens[problem[:resource][:start]].next_token_of(:NAME)
+    first_param_name_token = problem[:resource][:param_tokens].first
     first_param_comma_token = first_param_name_token.next_token_of(:COMMA)
     ensure_param_name_token = first_param_comma_token.next_token_of(:NAME, :value => 'ensure')
 


### PR DESCRIPTION
Currently the fix method for this check relies upon the position of the
first parameter in the tokens array to operate which is determined when
the manifest is first loaded. If checks with fix methods that add or
remove tokens (like the `trailing_whitespace` check) run before this
check, the saved position becomes no longer accurate causing the fix
method to fail.

Fixes #906
Fixes #905
Fixes #839