### PR TITLE
Improve Rake task

### DIFF
--- a/lib/puppet-lint/tasks/puppet-lint.rb
+++ b/lib/puppet-lint/tasks/puppet-lint.rb
@@ -20,6 +20,7 @@ class PuppetLint
     attr_accessor :ignore_paths
     attr_accessor :with_filename
     attr_accessor :disable_checks
+    attr_accessor :only_checks
     attr_accessor :fail_on_warnings
     attr_accessor :error_level
     attr_accessor :log_format
@@ -40,6 +41,7 @@ class PuppetLint
       @pattern = DEFAULT_PATTERN
       @with_filename = true
       @disable_checks = []
+      @only_checks = []
       @ignore_paths = []
 
       define(args, &task_block)
@@ -54,6 +56,17 @@ class PuppetLint
       Rake::Task[@name].clear if Rake::Task.task_defined?(@name)
       task @name do
         PuppetLint::OptParser.build
+
+        if Array(@only_checks).any?
+          enable_checks = Array(@only_checks).map(&:to_sym)
+          PuppetLint.configuration.checks.each do |check|
+            if enable_checks.include?(check)
+              PuppetLint.configuration.send("enable_#{check}")
+            else
+              PuppetLint.configuration.send("disable_#{check}")
+            end
+          end
+        end
 
         Array(@disable_checks).each do |check|
           PuppetLint.configuration.send("disable_#{check}")


### PR DESCRIPTION
When using the Rake task with an open glob such as `**/*`, `puppet-lint` will fail to load directories.