### PR TITLE
Disallow empty lines between docs and class/define

### DIFF
--- a/lib/puppet-lint/plugins/check_documentation/documentation.rb
+++ b/lib/puppet-lint/plugins/check_documentation/documentation.rb
@@ -30,8 +30,12 @@ PuppetLint.new_check(:documentation) do
   end
 
   def find_comment_token(start_token)
+    newlines = 0
+
     prev_token = start_token.prev_token
     while !prev_token.nil? && WHITESPACE_TOKENS.include?(prev_token.type)
+      newlines += 1 if prev_token.type == :NEWLINE
+      break if newlines > 1
       prev_token = prev_token.prev_token
     end
 

--- a/spec/puppet-lint/plugins/check_documentation/documentation_spec.rb
+++ b/spec/puppet-lint/plugins/check_documentation/documentation_spec.rb
@@ -29,6 +29,24 @@ describe 'documentation' do
     end
   end
 
+  describe 'incorrectly documented class' do
+    let(:code) do
+      <<-END
+        # foo
+
+        class test {}
+      END
+    end
+
+    it 'should only detect a single problem' do
+      expect(problems).to have(1).problem
+    end
+
+    it 'should create a warning' do
+      expect(problems).to contain_warning(class_msg).on_line(3).in_column(9)
+    end
+  end
+
   describe 'undocumented defined type' do
     let(:code) { 'define test {}' }
 


### PR DESCRIPTION
puppet-strings doesn't parse documentation if there is an empty line between the comments and the actual class/define. This enhances the check by only accepting a single newline.