### PR TITLE
Correctly lex non-keyword type tokens in interpolation

### DIFF
--- a/lib/puppet-lint/lexer.rb
+++ b/lib/puppet-lint/lexer.rb
@@ -124,6 +124,8 @@ class PuppetLint
     # value of the token.
     KNOWN_TOKENS = [
       [:WHITESPACE, %r{\A(#{WHITESPACE_RE}+)}],
+      # FIXME: Future breaking change, the following :TYPE tokens conflict with
+      #        the :TYPE keyword token.
       [:TYPE, %r{\A(Integer|Float|Boolean|Regexp|String|Array|Hash|Resource|Class|Collection|Scalar|Numeric|CatalogEntry|Data|Tuple|Struct|Optional|NotUndef|Variant|Enum|Pattern|Any|Callable|Type|Runtime|Undef|Default|Sensitive)\b}], # rubocop:disable Metrics/LineLength
       [:CLASSREF, %r{\A(((::){0,1}[A-Z][-\w]*)+)}],
       [:NUMBER, %r{\A\b((?:0[xX][0-9A-Fa-f]+|0?\d+(?:\.\d+)?(?:[eE]-?\d+)?))\b}],
@@ -417,7 +419,7 @@ class PuppetLint
           lexer = PuppetLint::Lexer.new
           lexer.tokenise(segment[1])
           lexer.tokens.each_with_index do |t, i|
-            type = i.zero? && (t.type == :NAME || KEYWORDS.include?(t.type.to_s.downcase)) ? :VARIABLE : t.type
+            type = i.zero? && t.interpolated_variable? ? :VARIABLE : t.type
             tokens << new_token(type, t.value, :raw => t.raw)
           end
         when :UNENC_VAR
@@ -449,7 +451,7 @@ class PuppetLint
           lexer = PuppetLint::Lexer.new
           lexer.tokenise(segment[1])
           lexer.tokens.each_with_index do |t, i|
-            type = i.zero? && t.type == :NAME ? :VARIABLE : t.type
+            type = i.zero? && t.interpolated_variable? ? :VARIABLE : t.type
             tokens << new_token(type, t.value, :raw => t.raw)
           end
         when :UNENC_VAR

--- a/lib/puppet-lint/lexer/token.rb
+++ b/lib/puppet-lint/lexer/token.rb
@@ -199,6 +199,12 @@ class PuppetLint
         end
         nil
       end
+
+      def interpolated_variable?
+        return false if type == :TYPE && value != 'type'
+        return true if type == :NAME
+        PuppetLint::Lexer::KEYWORDS.include?(type.to_s.downcase)
+      end
     end
   end
 end

--- a/spec/puppet-lint/plugins/check_variables/variable_is_lowercase_spec.rb
+++ b/spec/puppet-lint/plugins/check_variables/variable_is_lowercase_spec.rb
@@ -22,4 +22,32 @@ describe 'variable_is_lowercase' do
       expect(problems).to have(0).problems
     end
   end
+
+  context 'when typecasting inside an interpolation' do
+    let(:code) { %("${Integer(fact('memory.system.total_bytes'))}") }
+
+    it 'should not detect any problems' do
+      expect(problems).to have(0).problems
+    end
+  end
+
+  context 'when an interpolated variable contains an uppercase letter' do
+    let(:code) { '"${fooBar}"' }
+
+    it 'should only detect a single problem' do
+      expect(problems).to have(1).problem
+    end
+
+    it 'should create a warning' do
+      expect(problems).to contain_warning(msg).on_line(1).in_column(4)
+    end
+  end
+
+  context 'when an interpolated variable only contains lowercase letters' do
+    let(:code) { '"${foobar}"' }
+
+    it 'should not detect any problems' do
+      expect(problems).to have(0).problems
+    end
+  end
 end


### PR DESCRIPTION
There's a conflict in the current lexer that where the `type` keyword
token (`:type = :TYPE, :value => 'type'`) conflicts with the known type
name tokens (e.g. `:type => :TYPE, :value => 'Integer'`).

The proper solution to this would be to use a different token type for
these two use cases, but that is a breaking change as the token types
are considered public API for semver purposes. Until the next major
release where this can be introduced, this fix will do.

Fixes #929 