### PR TITLE
Select parameter tokens based on preceeding code token

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,10 +31,15 @@ group :test do
 end
 
 group :development do
-  # For Changelog generation
   if RUBY_VERSION > '1.9'
-    gem 'github_changelog_generator',                                 :require => false if RUBY_VERSION >= '2.2.2'
-    gem 'github_changelog_generator', '~> 1.13.0',                    :require => false if RUBY_VERSION < '2.2.2'
-    gem 'rack', '~> 1.0',                                             :require => false if RUBY_VERSION < '2.2.2'
+    # For Changelog generation
+    if RUBY_VERSION >= '2.2.2'
+      gem 'github_changelog_generator', :require => false
+    else
+      gem 'github_changelog_generator', '~> 1.13.0', :require => false
+      gem 'rack', '~> 1.0', :require => false
+    end
+
+    gem 'pry'
   end
 end

--- a/spec/puppet-lint/plugins/check_classes/parameter_order_spec.rb
+++ b/spec/puppet-lint/plugins/check_classes/parameter_order_spec.rb
@@ -147,5 +147,23 @@ describe 'parameter_order' do
 
       it { expect(problems).to have(0).problems }
     end
+
+    context "#{type} parameter with array operation" do
+      let(:code) do
+        <<-END
+          #{type} ntp (
+            # XXX: remove self from list
+            Array[String] $ntp_servers = [
+              'foo',
+              'bar',
+              'baz',
+            ] - $::fqdn,
+            Array[String] $pools       = [],
+          ) { }
+        END
+      end
+
+      it { expect(problems).to have(0).problems }
+    end
   end
 end


### PR DESCRIPTION
Class/defined type parameter name tokens can be more accurately selected
based on the type of non-whitespace token that preceeds it.

`:VARIABLE` preceeded by:
  * `:LPAREN` - First parameter, no data type
  * `:COMMA` - Subsequent parameters, no data type
  * `:TYPE` - Parameter with a simple data type (e.g. `String`)
  * `:RBRACK` - Parameter with a complex data type (e.g. `Array[String]`)

As before, tokens within balanced pairs of parens will be automatically
skipped over, preventing a function call that takes a variable parameter
from generating a false positive in the first 2 cases.

Fixes #930