### PR TITLE
Appveyor: run on Ruby 2.5/2.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,49 +1,66 @@
 name: CI
-on:
-    push:
-        branches:
-            - master
-    pull_request:
-    schedule:
-        - cron: '3 0 * * *'
-jobs:
-    lint:
-        name: RuboCop
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v2
-            - uses: ruby/setup-ruby@v1
-              with:
-                  ruby-version: 2.6
-                  bundler-cache: true
-            - run: bundle install
-            - run: bundle exec rake rubocop
 
-    spec:
-        strategy:
-            fail-fast: false
-            matrix:
-                os:
-                    - ubuntu
-                    - windows
-                ruby:
-                    - 2.1
-                    - 2.2
-                    - 2.3
-                    - 2.4
-                    - 2.5
-                    - 2.6
-                    - 2.7
-        needs: lint
-        name: RSpec - ${{ matrix.os }} - Ruby ${{ matrix.ruby }} 
-        runs-on: ${{ matrix.os }}-latest
-        env:
-            COVERAGE: yes
-        steps:
-            - uses: actions/checkout@v2
-            - uses: ruby/setup-ruby@v1
-              with:
-                  ruby-version: ${{ matrix.ruby }}
-                  bundler-cache: true
-            - run: bundle install
-            - run: bundle exec rake
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  schedule:
+    - cron: "3 0 * * *"
+
+jobs:
+  lint:
+    name: RuboCop
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7
+          bundler-cache: true
+      - run: bundle exec rake rubocop
+
+  spec:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["ubuntu-latest", "windows-latest"]
+        ruby:
+          - "2.4"
+          - "2.5"
+          - "2.7"
+    needs: lint
+    name: RSpec - ${{ matrix.os }} - Ruby ${{ matrix.ruby }}
+    runs-on: ${{ matrix.os }}
+    env:
+      COVERAGE: yes
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - run: bundle exec rake
+
+  release_tests:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["ubuntu-latest", "windows-latest"]
+        ruby:
+          - "2.4"
+          - "2.5"
+          - "2.7"
+    needs: lint
+    name: Release Tests - ${{ matrix.os }} - Ruby ${{ matrix.ruby }}
+    runs-on: ${{ matrix.os }}
+    env:
+      BUNDLE_WITHOUT: development system_tests
+      CHECK: ci
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - run: bundle exec rake ci

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @puppetlabs/devx

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,8 +7,8 @@ branches:
 # ruby versions under test
 environment:
   matrix:
-    - RUBY_VERSION: 193
-    - RUBY_VERSION: 200
+    - RUBY_VERSION: 250
+    - RUBY_VERSION: 270
 
 matrix:
   allow_failures:

--- a/lib/puppet-lint/tasks/release_test.rb
+++ b/lib/puppet-lint/tasks/release_test.rb
@@ -55,7 +55,9 @@ def with_puppet_lint_head
 end
 
 task :release_test do
-  branch = if ENV['APPVEYOR']
+  branch = if ENV['GITHUB_REF']
+             ENV['GITHUB_REF']
+           elsif ENV['APPVEYOR']
              ENV['APPVEYOR_PULL_REQUEST_HEAD_REPO_BRANCH']
            elsif ENV['TRAVIS']
              ENV['TRAVIS_PULL_REQUEST_BRANCH']


### PR DESCRIPTION
previously appveyor used ruby 1.93/2.0. Those versions are dead and
block the CI pipeline. With this change they are uplifted to Ruby
2.5/2.7 which Puppet 6/7 vendors.